### PR TITLE
Unnecessary Margins in Sessions/Speakers details

### DIFF
--- a/app/components/sessions/sessiondialog.html
+++ b/app/components/sessions/sessiondialog.html
@@ -12,7 +12,7 @@
             </div>
         </md-toolbar>
         <md-dialog-content>
-            <div>
+            <div class="sub_content">
                 <md-subheader>{{sdc.session.subtitle}}</md-subheader>
                 <md-chips>
                     <md-chip> <b> Duration: </b> {{ sdc.duration(sdc.session)}} </md-chip>

--- a/app/components/speakers/speakerdialog.html
+++ b/app/components/speakers/speakerdialog.html
@@ -12,7 +12,7 @@
             </div>
         </md-toolbar>
         <md-dialog-content>
-            <div>
+            <div class="sub_content">
                 <md-subheader>{{sdc.speaker.subtitle}}</md-subheader>
                 <md-chips ng-model="sdc.speakerChips" readonly="true">
                     <md-chip-template ng-if="$chip.value.length>0">

--- a/app/components/tracks/trackdialog.html
+++ b/app/components/tracks/trackdialog.html
@@ -16,7 +16,7 @@
             <div ng-if="tdc.count(tdc.track, tdc.allSessions)>0">
                 <md-list-item ng-repeat="session in tdc.sessionsDetail(tdc.track, tdc.allSessions)">
                     <div>
-                        <br/><br/>
+                        
                         <b> {{session.title}} </b>
                         <md-subheader>{{session.subtitle}}</md-subheader>
                         <md-chips>

--- a/main.css
+++ b/main.css
@@ -32,7 +32,6 @@
     padding: 0px 0px 0px 0px;
 }
 
-.md-subheader {
-    margin-top: -21px !important;
+.sub_content {
+    margin-top: -22px !important;
 }
-

--- a/main.css
+++ b/main.css
@@ -27,3 +27,12 @@
     width: 75% !important;
     height: auto !important;
 }
+
+.md-subheader .md-subheader-inner {
+    padding: 0px 0px 0px 0px;
+}
+
+.md-subheader {
+    margin-top: -21px !important;
+}
+


### PR DESCRIPTION
I didn't want destroy anything so I created two new things in .css and set one of them to !important 
If you want I can look for these two things and change it in original form.
https://github.com/fossasia/open-event-webapp/issues/83
