### PR TITLE
Update sponsors test data with the new google logo #113

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,9 +44,9 @@
 
 
     <!-- inject:js -->
+    <script src="assets/js/Utils.js"></script>
     <script src="assets/js/leaflet.js"></script>
     <script src="assets/js/twitter-widget.js"></script>
-    <script src="assets/js/Utils.js"></script>
     <script src="bower_components/angular/angular.js"></script>
     <script src="bower_components/angular-simple-logger/dist/angular-simple-logger.js"></script>
     <script src="bower_components/angular-animate/angular-animate.js"></script>

--- a/testapi/event/1/sponsors
+++ b/testapi/event/1/sponsors
@@ -3,7 +3,7 @@
     {
       "name": "Google",
       "url": "http://google.com",
-      "logo": "http://upload.wikimedia.org/wikipedia/commons/thumb/3/30/Googlelogo.png/320px-Googlelogo.png"
+      "logo": "http://res.cloudinary.com/demo/image/fetch/fl_png8/https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png"
     },
     {
       "name": "Moz",


### PR DESCRIPTION
![selection_008](https://cloud.githubusercontent.com/assets/6227784/13195019/41ab0104-d7cc-11e5-9490-6fbf9195b450.png)

Changed the Google logo to the recent one. 
