### PR TITLE
updated map location working

### DIFF
--- a/app/components/map/MapController.js
+++ b/app/components/map/MapController.js
@@ -38,18 +38,17 @@ mapModule.controller('MapController',
             }
         }
     });
-	
+
 
 }]);
 
-mapModule.controller('AddressController', 
+mapModule.controller('AddressController',
 	['$scope', '$sessionStorage',
-		function($scope, $sessionStorage) { 
+		function($scope, $sessionStorage) {
 	var mc = this;
 	mc.Event = $sessionStorage.event;
   $scope.street = mc.Event.address.street;
-  $scope.locality = mc.Event.address.locality; 
-  $scope.city = mc.Event.address.city; 
-  $scope.country = mc.Event.address.country; 
-  $scope.postalCode = mc.Event.address.postalCode; 
+  $scope.city = mc.Event.address.city;
+  $scope.country = mc.Event.address.country;
+  $scope.postalCode = mc.Event.address.postalCode;
 }]);

--- a/app/components/map/map.html
+++ b/app/components/map/map.html
@@ -3,7 +3,7 @@
         <div class="md-whiteframe-z3 md-padding">
             <leaflet
                     center="locationCenter" markers="markers"
-                    center="london" height="480px" width="100%">
+                    center="london" height="600px" width="100%">
 
             </leaflet>
         </div>
@@ -13,7 +13,6 @@
 
 <div ng-controller="AddressController">
 	<h1>{{ street }}
-	</br>{{ locality }}
 	</br>{{ city }}
 	</br>{{ country }}
 	</br>{{ postalCode }}

--- a/testapi/event/1/event
+++ b/testapi/event/1/event
@@ -1,25 +1,24 @@
 {
   "events": [
     {
-      "begin": "2015-05-04T00:00:00",
+      "begin": "2016-03-18T00:00:00",
       "color": "#000", 
       "email": "", 
-      "end": "2015-05-09T00:00:00",
+      "end": "2016-03-20T00:00:00",
       "id": 1, 
-      "latitude": 52.49814, 
-      "location_name": "Station Berlin", 
+      "latitude": 1.3329, 
+      "location_name": "Science Centre Singapore", 
 	  "address": {
-		"street" : "Luckenwalder Str. 4-6",
-		"locality": "Kreuzberg",
-		"city" : "Berlin",
-		"country" : "Germany",
-		"postalCode": 10963
+		"street" : "15 Science Centre Road",
+		"city" : " Singapore",
+		"country" : "Singapore",
+		"postalCode": 609081
 		},
       "logo": "Zrzut_ekranu_2015-08-01_o_23.19.01.png", 
-      "longitude": 13.374538, 
-      "name": "re:Publica 2015",
-      "slogan": "Finding Europe",
-      "url": "http://15.re-publica.de/"
+      "longitude": 103.7358, 
+      "name": "FOSSASIA",
+      "slogan": "Open-Event",
+      "url": "http://16.re-publica.de/"
     }
   ]
 }


### PR DESCRIPTION
Now the map location is set as per the current event location.

![shot](https://cloud.githubusercontent.com/assets/9693795/13846589/3f82d602-ec6e-11e5-95b3-dfa789a3c44b.png)


@championswimmer  have a look. it resolves #138
