### PR TITLE
sponsorsLogoMadeVisible

### DIFF
--- a/app/components/sponsors/sponsors.html
+++ b/app/components/sponsors/sponsors.html
@@ -19,7 +19,7 @@
                           md-rowspan="{{2}}"
                           md-colspan="{{2}}"
                           md-colspan-sm="1">
-                <img class="sponsor-logo"
+                <img class="logo"
                         src="{{sponsor.logo}}"/>
 
 

--- a/main.css
+++ b/main.css
@@ -22,7 +22,7 @@
     color: darkblue !important;
 }
 
-.sponsor-logo {
+.logo {
     display: block;
     width: 75% !important;
     height: auto !important;


### PR DESCRIPTION
due to the presence of the class name="sponsor-logo" it was making the view of the sponsor image somehow 0x0 pixels.
![sponsors](https://cloud.githubusercontent.com/assets/9693795/14001577/ae92dfda-f16c-11e5-95fd-f9a1ab9a21df.png)

changing the class name makes it work all fine.
![final_sponsor](https://cloud.githubusercontent.com/assets/9693795/14001596/d32e188c-f16c-11e5-98dd-f5632a24c4b7.png)
initially there were some `#shadow.root` style which was making all this, but now unable to see that style attribute.

@championswimmer can you explain it please.