### PR TITLE
Tracks Page UX improvements  

### DIFF
--- a/src/generator/backend/_scss/application.scss
+++ b/src/generator/backend/_scss/application.scss
@@ -305,14 +305,19 @@ a {
   background: $light-skyblue; 
   width:auto; 
   margin-left: 4%; 
-  max-width: 500px;
   text-shadow: 1px 1px 0 rgba(255,255,255,.15);
   box-shadow: 0 1px 2px rgba(0,0,0,0.25); 
   word-wrap: break-word;
+  max-width: 600px;
   } 
 .sizeevent {
   padding: 2%;
   width: auto;
+  font-weight: 400;
+  font-style: normal;
+}
+.sizeevent span {
+  font-weight :700;
 }
 .trackwidth {
   width: 112px;
@@ -392,7 +397,7 @@ a {
     background-color: #fff;
       .pop-over {
         padding:2%;
-        max-height: 260px;
+        max-height: 160px;
         overflow-y: auto;
         overflow-x: hidden;
         margin:10px;
@@ -408,6 +413,10 @@ a {
         height: 35px;
         padding: 5px 5px 0;
         border-bottom: 1px solid #ddd
+      }
+      .pop-speakers {
+        max-height: 230px;
+        overflow-y: overlay;
       }
     }
   

--- a/src/generator/backend/_scss/application.scss
+++ b/src/generator/backend/_scss/application.scss
@@ -383,7 +383,6 @@ a {
 
 .pop-box{
   width:420px;
-  max-height:499px;
   min-height:255px;
   height: auto;
   z-index:1000;
@@ -403,8 +402,22 @@ a {
         margin:10px;
       }
       .pop-footer {
-        height:38px;
-        background-color :#fff;
+        border-top-left-radius: 5px;
+        border-top-right-radius: 5px;
+        background: #fff;
+        padding:2%;
+        line-height: .80em;
+        .titlecolor{
+          width: 12px;
+          height: 12px;
+          border-radius: 50%;
+        }
+        .title-inline { 
+          padding:0;
+          li{
+           display:inline-block;
+          }
+        } 
       }
       .pop-header {
         border-top-left-radius: 5px;
@@ -412,7 +425,7 @@ a {
         background: #efefef;
         height: 35px;
         padding: 5px 5px 0;
-        border-bottom: 1px solid #ddd
+        border-bottom: 1px solid #ddd;
       }
       .pop-speakers {
         max-height: 230px;

--- a/src/generator/backend/_scss/application.scss
+++ b/src/generator/backend/_scss/application.scss
@@ -305,7 +305,9 @@ a {
   background: $light-skyblue; 
   width:auto; 
   margin-left: 4%; 
-  max-width: 500px; 
+  max-width: 500px;
+  text-shadow: 1px 1px 0 rgba(255,255,255,.15);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.25); 
   word-wrap: break-word;
   } 
 .sizeevent {
@@ -341,7 +343,7 @@ a {
 } 
 .tracks {
   min-height: 70px; 
-  border-left: 1px solid $black; 
+  border-left: 1px solid rgba(0,0,0,.10);
 }
 /* Pop over Track */
 
@@ -352,7 +354,7 @@ a {
   overflow: hidden;
   left:6px;
   z-index: 1000;
-  margin-top: -3%;
+  margin-top: -2%;
 
   span {
     display: block;
@@ -375,28 +377,37 @@ a {
 }
 
 .pop-box{
-
-  width:300px;
-  height:164px;
+  width:420px;
+  max-height:499px;
+  min-height:255px;
+  height: auto;
   z-index:1000;
   position:absolute;
-  left:187px;
+  left:30px;
   border-radius:4px;
   border: 1px solid #c1c1c1;
   transition: all 0.5s ease;
   background-color:white;
     .pop {
-    background-color: #efefef;
-    padding:1%;
-    max-height: 126px;
-    overflow-y: auto;
-    overflow-x: hidden;
+    background-color: #fff;
       .pop-over {
         padding:2%;
+        max-height: 260px;
+        overflow-y: auto;
+        overflow-x: hidden;
+        margin:10px;
       }
       .pop-footer {
         height:38px;
         background-color :#fff;
+      }
+      .pop-header {
+        border-top-left-radius: 5px;
+        border-top-right-radius: 5px;
+        background: #efefef;
+        height: 35px;
+        padding: 5px 5px 0;
+        border-bottom: 1px solid #ddd
       }
     }
   

--- a/src/generator/backend/assets/js/popover.js
+++ b/src/generator/backend/assets/js/popover.js
@@ -4,12 +4,12 @@ $(document).ready(function() {
   var popbox = $('.pop-box');
   popbox.hide();
   if($(window).width() < 768) {
-    $('.item').click(function(event) {
+    $('.sizeevent').click(function(event) {
       popBox(event);
     });
   }
   else {
-    $('.item').hover(function(event) {
+    $('.sizeevent').hover(function(event) {
       popBox(event);
     });
   }
@@ -19,9 +19,9 @@ $(document).ready(function() {
     popbox.hide();
     event.preventDefault();
     event.stopPropagation();
-
-    var track = $(event.target);
-    var link  = track.children(0);
+    
+   var track = $(event.target);
+     /*var link  = track.children(0);
 
     if($(link).offset() === undefined) {
       var offset = $(track).offset();
@@ -32,34 +32,36 @@ $(document).ready(function() {
     }
 
     var nextOfpop = $(track).next();
-    var position = offset.top - link.height() - 30;
-    var left = offset.left;
+    //var position = offset.top - link.height() - 30;
+    //var left = offset.left;
 
     if($(window).width() >= 320 && $(window).width() < 481) {
-      var position = offset.top - link.height() - 15;
+      //var position = offset.top - link.height() - 15;
     }
     else if($(window).width() >= 481 && $(window).width() < 597) {
-      var position = offset.top - link.height() - 20;
+      //var position = offset.top - link.height() - 20;
     }
     else if($(window).width() >= 597 && $(window).width() < 641) {
-      var position = offset.top - link.height() - 46;
+      //var position = offset.top - link.height() - 46;
     }
     else if($(window).width() >= 641 && $(window).width() < 961) {
-      var position = offset.top - link.height() - 22;
+      //var position = offset.top - link.height() - 22;
     }
     else if($(window).width() >= 961 && $(window).width() < 1025) {
-      var left = left - 180;
+      //var left = left - 180;
     }
     else {
-      var left = left - 248;
+      //var left = left - 248;
     }
-    if(offset.top) {
-      var toptrack = position;
-      $(nextOfpop).css({'top': toptrack,
-                      'left': left
-    });
-      $(track).next().show();
+   if(offset.top) {
+      //var toptrack = position;
+      //$(nextOfpop).css({'top': toptrack,
+                      //'left': left
+    //});
+    
     }
+*/
+  $(track).next().show();
     $(document).mouseup(function(e) {
       var container = popbox;
 

--- a/src/generator/backend/templates/tracks.hbs
+++ b/src/generator/backend/templates/tracks.hbs
@@ -64,12 +64,23 @@
             </div>
             <div class="pop-container" style="color:black";>
               <div class="pop">
-                  <h6 id="headline"><strong>Speakers</strong></h6>
+                <div class="pop-header">
+                  <span>
+                  <a class="session-link" href="#{{session_id}}">
+                    Share <i class="fa fa-link"></i>
+                  </a>
+                  <input class="inputbox" type="text" onclick="this.select()" value="http://opentechsummit.net/programm/#{{session_id}}" style="display:none;">
+                  </span>
+                </div>
+                <div class="pop-over row">
+                  {{#linkify}}{{description}}{{/linkify}}
+                </div>
+                <hr style="clear:both;width:75%;">
+                <h5>Speakers</h5>
                  {{#each speakers_list}}
-                 
                  <div class="pop-over row">
-                   <div class="col-md-2"><img src="{{{photo}}}"></div>
-                   <div class="col-md-10">{{name}}</div>
+                   <div class="col-md-5"><img style="width:75px;height:75px border-radius:50%;" src="{{{photo}}}"></div>
+                   <div class="col-md-7">{{name}} {{organisation}}</div>
                 </div>
                 
                   {{/each}}
@@ -94,6 +105,11 @@
     <script type="text/javascript" src="./js/popover.js"></script>
 
    <script>
+    $(document).ready(function(){
+      $('.session-link').click(function() {
+        $(this).next('.inputbox').toggle().select();
+        });
+      });
     $(function() {  
   $('.nav.navbar-nav > li a').removeClass('active');
   var linkUrl=window.location.href.split("/");

--- a/src/generator/backend/templates/tracks.hbs
+++ b/src/generator/backend/templates/tracks.hbs
@@ -47,16 +47,18 @@
       </h2>
       <div id=track-list class="container">
         {{#tracks}}
+        
         <div class="row">
-          <div style="background-color:{{{color}}}" class="trackwidth  event col-md-offset-1 col-xs-1 col-md-1">
-           <h6 class="text">{{title}}</h6>
+          <div class="col-xs-2 col-md-3">
+           <h4 class="text"><strong>{{title}}</strong></h4>
+           <h4 class="text">{{date}}</h4>
           </div>
           
-          <div class="tracks col-xs-7 col-md-9">
+          <div class="tracks col-xs-10 col-md-9">
           {{#sessions}}
 
             <h4 style="background-color:{{{../color}}}"  class="sizeevent event">
-            <span>{{start}} - {{end}} &nbsp;&bull;&nbsp;</span>
+            <span>{{start}} - {{end}}&nbsp;&bull;&nbsp;</span>
             {{title}}</h4>
              <div style="display:none;" class="pop-box">
             <div class="arrow">
@@ -76,17 +78,26 @@
                   {{#linkify}}{{description}}{{/linkify}}
                 </div>
                 <hr style="clear:both;width:75%;">
-                <h5 style="padding-left:20px" class=""><strong>Speakers</strong></h5>
+                <h5 style="padding-left:20px" class="text"><strong>Speakers</strong></h5>
                 <div class="pop-speakers"> 
                  {{#each speakers_list}}
                 
                  <div class="pop-over row">
-                   <div class="col-md-3"><img style="width:75px;height:75px border-radius:50%;" src="{{{photo}}}"></div>
-                   <div class="col-md-9"><h4>{{name}}</h4></div>
+                   <div class="col-md-3 col-xs-3"><img style="width:75px;height:75px; border-radius:50%;" src="{{{photo}}}"></div>
+                   <div class="col-xs-9 col-md-9"><h4>{{name}}</h4></div>
                   </div>
                 
                   {{/each}}
                 </div>  
+                <hr style="clear:both;width:75%;">
+                <div class="pop-footer">
+                  <p>{{../date}}&nbsp; &nbsp;{{start}} - {{end}}</p>
+                  <p>{{location}}</p>
+                  <ul class="title-inline">
+                  <li  style="background-color:{{{../color}}}" class="titlecolor"></li>&nbsp;
+                  <li>{{../title}}</li>
+                  </ul>
+                </div>
               </div>
             </div>
           </div>

--- a/src/generator/backend/templates/tracks.hbs
+++ b/src/generator/backend/templates/tracks.hbs
@@ -58,29 +58,28 @@
             <h5 style="background-color:{{{../color}}}"  class="sizeevent event">
             <p>{{start}} - {{end}}</p>
             {{title}}</h5>
-          {{/sessions}}
-          </div>
-           
-          <div style="display:none;" class="pop-box">
+             <div style="display:none;" class="pop-box">
             <div class="arrow">
-            <span></span>
+              <span></span>
             </div>
             <div class="pop-container" style="color:black";>
               <div class="pop">
                   <h6 id="headline"><strong>Speakers</strong></h6>
-                 {{#sessions}}
+                 {{#each speakers_list}}
                  
                  <div class="pop-over row">
-                   <div style="background-color:{{{../color}}}" class="sesroom event col-md-12">
-                   <span>{{start}} - {{end}}</span>
-                   <b>{{title}}</b>
-                  </div>
+                   <div class="col-md-2"><img src="{{{photo}}}"></div>
+                   <div class="col-md-10">{{name}}</div>
                 </div>
                 
-                  {{/sessions}}
+                  {{/each}}
               </div>
             </div>
           </div>
+          {{/sessions}}
+          </div>
+           
+
         </div><br>
         {{/tracks}}
       </div>

--- a/src/generator/backend/templates/tracks.hbs
+++ b/src/generator/backend/templates/tracks.hbs
@@ -52,12 +52,12 @@
            <h6 class="text">{{title}}</h6>
           </div>
           
-          <div class="tracks col-xs-7 col-md-7">
+          <div class="tracks col-xs-7 col-md-9">
           {{#sessions}}
 
-            <h5 style="background-color:{{{../color}}}"  class="sizeevent event">
-            <p>{{start}} - {{end}}</p>
-            {{title}}</h5>
+            <h4 style="background-color:{{{../color}}}"  class="sizeevent event">
+            <span>{{start}} - {{end}} &nbsp;&bull;&nbsp;</span>
+            {{title}}</h4>
              <div style="display:none;" class="pop-box">
             <div class="arrow">
               <span></span>
@@ -76,14 +76,17 @@
                   {{#linkify}}{{description}}{{/linkify}}
                 </div>
                 <hr style="clear:both;width:75%;">
-                <h5>Speakers</h5>
+                <h5 style="padding-left:20px" class=""><strong>Speakers</strong></h5>
+                <div class="pop-speakers"> 
                  {{#each speakers_list}}
+                
                  <div class="pop-over row">
-                   <div class="col-md-5"><img style="width:75px;height:75px border-radius:50%;" src="{{{photo}}}"></div>
-                   <div class="col-md-7">{{name}} {{organisation}}</div>
-                </div>
+                   <div class="col-md-3"><img style="width:75px;height:75px border-radius:50%;" src="{{{photo}}}"></div>
+                   <div class="col-md-9"><h4>{{name}}</h4></div>
+                  </div>
                 
                   {{/each}}
+                </div>  
               </div>
             </div>
           </div>


### PR DESCRIPTION
@mariobehling  @championswimmer, Please suggest your view point.
Issue #474
Please consider the following improvements

- [x] Sessions according to each track with the color.
- [x] On hovering each session a pop-over appear.
- [x] Pop over contain
      1.  header with option to share session.
      2.  body which shows all speakers of the selected session.
      3. footer showing room of that session and some other relevant information
- [x] On clicking outside the pop-over should disappear.
- [x] Optimize pop-over.js.
- [x] Add home in navbar to go back to webapp generator page.


![111](https://cloud.githubusercontent.com/assets/12194719/16928835/66afd064-4d52-11e6-960c-df714892e759.png)

![123](https://cloud.githubusercontent.com/assets/12194719/16929799/eaf8a28e-4d56-11e6-8f45-0b06534d7d8d.png)

