### PR TITLE
check for empty strings and avoid downloading them as well

### DIFF
--- a/src/generator/backend/fold.js
+++ b/src/generator/backend/fold.js
@@ -37,7 +37,7 @@ function foldByTrack(sessions, speakers, trackInfo, reqOpts) {
   if (reqOpts.assetmode === 'download') {
     const appFolder = reqOpts.email + '/' + slugify(reqOpts.name);
     speakers.forEach((speaker) => {
-      if (speaker.photo !== null) {
+      if (speaker.photo !== null && speaker.photo != "") {
         if (speaker.photo.substring(0, 4) === 'http') {
           speaker.photo = urlencode(distHelper.downloadSpeakerPhoto(appFolder, speaker.photo));
         } else {
@@ -243,7 +243,7 @@ function foldByLevel(sponsors ,reqOpts) {
     if (levelData[sponsor.level] === undefined) {
       levelData[sponsor.level] = [];
     }
-    if (sponsor.logo !== null) {
+    if (sponsor.logo !== null && sponsor.logo != "") {
       if (sponsor.logo.substring(0, 4) === 'http') {
         sponsor.logo = urlencode(distHelper.downloadSponsorPhoto(appFolder, sponsor.logo));
       } else {


### PR DESCRIPTION
this stops downloading non existent images 

earlier was only checking null. should check empty strings too. 

please check and merge @aayusharora 

Signed-off-by: Arnav Gupta <championswimmer@gmail.com>