### PR TITLE
reduce log lines as heroku provides only heroku logs

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -14,9 +14,7 @@ app.use(compression());
 var errorHandler;
 
 io.on('connection', function(socket){
-  console.log('a user connected');
   socket.on('disconnect', function () {
-    console.log('user disconnected')
   });
 
   socket.on('live', function(formData) {

--- a/src/backend/dist.js
+++ b/src/backend/dist.js
@@ -38,10 +38,6 @@ const downloadJson = function(appPath, endpoint, jsonFile, cb) {
         .on('response', function(response) {
           if (response.statusCode != 200) {
             cb(new Error('Response = ' + response.statusCode + 'received'));
-          } else {
-            console.log('Got response');
-            console.log(response.statusCode); // 200
-            console.log(response.headers['content-type']); // 'image/png'
           }
         })
         .pipe(fileStream);

--- a/src/backend/fold.js
+++ b/src/backend/fold.js
@@ -371,7 +371,6 @@ function foldBySpeakers(speakers ,sessions, tracksData, reqOpts) {
       }
 
       }
-      //console.log(speaker.photo);
     });
   }  
 
@@ -410,7 +409,6 @@ function getAllSessions(speakerid , session, trackInfo){
   const sessionsMap = new Map(session.map((s) => [s.id, s]));
   speakerid.forEach((speaker) => {
     if(speaker !== undefined ) {
-      //console.log(speaker.id);
        sessiondetail.push({
         detail :sessionsMap.get(speaker.id)
       })

--- a/src/backend/generator.js
+++ b/src/backend/generator.js
@@ -89,7 +89,7 @@ exports.createDistDir = function(req, socket, callback) {
     (done) => {
         if (emit) socket.emit('live.process', {status: "Cleaning dist folder"});
       distHelper.cleanDist(appFolder, (cleanerr) => {
-        console.log('================================CLEANING\n\n\n\n');
+        console.log('================================CLEANING\n');
         if (cleanerr !== null) {
             console.log(cleanerr);
             return socket.emit('live.error', {status: "Error in cleaning dist folder"} );
@@ -98,7 +98,7 @@ exports.createDistDir = function(req, socket, callback) {
       });
     },
     (done) => {
-      console.log('================================MAKING\n\n\n\n');
+      console.log('================================MAKING\n');
       if (emit)socket.emit('live.process', {status: "Making dist folder"});
       distHelper.makeDistDir(appFolder);
       done(null, 'make');
@@ -106,7 +106,7 @@ exports.createDistDir = function(req, socket, callback) {
     (done) => {
       if (emit)socket.emit('live.process', {status: "Copying assets"});
       distHelper.copyAssets(appFolder, (copyerr) => {
-        console.log('================================COPYING\n\n\n\n');
+        console.log('================================COPYING\n');
 
         if (copyerr !== null) {
           console.log(copyerr);
@@ -116,7 +116,7 @@ exports.createDistDir = function(req, socket, callback) {
       });
     },
     (done) => {
-      console.log('================================COPYING JSONS\n\n\n\n');
+      console.log('================================COPYING JSONS\n');
       if (emit)socket.emit('live.process', {status: "Copying the JSONs"});
       switch (req.body.datasource) {
         case 'jsonupload':
@@ -124,7 +124,7 @@ exports.createDistDir = function(req, socket, callback) {
           done(null, 'cleanuploads');
           break;
         case 'eventapi':
-          console.log('================================FETCHING JSONS\n\n\n\n');
+          console.log('================================FETCHING JSONS\n');
           distHelper.fetchApiJsons(appFolder, req.body.apiendpoint, () => {
             done(null, 'cleanuploads');
           });
@@ -138,7 +138,7 @@ exports.createDistDir = function(req, socket, callback) {
       }
     },
     (done) => {
-      console.log('===============================COMPILING SASS\n\n\n\n');
+      console.log('===============================COMPILING SASS\n');
       if (emit) socket.emit('live.process', {status: "Compiling the SASS files"});
       sass.render({
         file: __dirname + '/_scss/_themes/_' + theme + '-theme/_' + theme + '.scss',
@@ -159,7 +159,7 @@ exports.createDistDir = function(req, socket, callback) {
       });
     },
     (done) => {
-      console.log('================================WRITING\n\n\n\n');
+      console.log('================================WRITING\n');
       if (emit)socket.emit('live.process', {status: "Compiling the HTML pages from templates"});
       const jsonData = getJsonData(req.body);
 
@@ -179,11 +179,10 @@ exports.createDistDir = function(req, socket, callback) {
       done(null, 'write');
     },
     (done) => {
-      console.log('=================================SENDING MAIL\n\n\n');
+      console.log('=================================SENDING MAIL\n');
       if (emit) socket.emit('live.process', {status: "Website is being generated"});
       
       mailer.sendMail(req.body.email, fold.slugify(req.body.name), () => {
-
         callback(appFolder);
         done(null, 'write');
         
@@ -196,7 +195,7 @@ exports.createDistDir = function(req, socket, callback) {
 
 exports.pipeZipToRes = function(email, appName, res) {
   const appFolder = email + '/' + appName;
-  console.log('================================ZIPPING\n\n\n\n');
+  console.log('================================ZIPPING\n');
   const zipfile = archiver('zip');
 
   zipfile.on('error', (err) => {

--- a/src/www/js/form.js
+++ b/src/www/js/form.js
@@ -89,8 +89,7 @@ function getData () {
     data.singlefileUpload = "";
     data.zipLength = 0;
   }
-  console.log(data);
-
+  
   return data;
 }
 


### PR DESCRIPTION
heroku provides only limited log history for apps

we should generate less logs so that it's easy to find errors, and not spam the console.log 

Signed-off-by: Arnav Gupta <championswimmer@gmail.com>