### PR TITLE
Expandable Sessions with Room Page bugs removed

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -1178,3 +1178,14 @@ a {
       }
     }
   }
+
+  .room-container {
+    .tip-description {
+      color: $black;
+      line-height: 2;
+    }
+  }
+
+  .blacktext {
+    color: $black;
+  }

--- a/src/backend/fold.js
+++ b/src/backend/fold.js
@@ -376,9 +376,10 @@ function sessionsByRooms(id, sessions, trackInfo) {
  return sessionInRooms;
 }
 
-function foldByRooms(room, sessions, trackInfo) {
-   const roomData = new Map();
+function foldByRooms(room, sessions, speakers, trackInfo) {
+  const roomData = new Map();
   const trackDetails = new Object();
+  const speakersMap = new Map(speakers.map((s) => [s.id, s]));
   const microlocationArray = [];
   trackInfo.forEach((track) => {
     trackDetails[track.id] = track.color;
@@ -391,8 +392,9 @@ function foldByRooms(room, sessions, trackInfo) {
 
     // generate slug/key for session
     const date = moment(session.start_time).format('YYYY-MM-DD');
-    const roomName = (session.microlocation == null) ? 'defroom' : session.microlocation.name;
+    const roomName = (session.microlocation == null) ? ' ' : session.microlocation.name;
     const slug = date ;
+    const tracktitle = (session.track == null) ? " " : session.track.name;
     let room = null;
 
     // set up room if it does not exist
@@ -421,7 +423,7 @@ function foldByRooms(room, sessions, trackInfo) {
       venue = "";
     }
 
-
+   
     room.sessions.push({
       start: moment(session.start_time).utcOffset(4).format('HH:mm'),
       color: returnTrackColor(trackDetails, (session.track == null) ? null : session.track.id),
@@ -429,7 +431,11 @@ function foldByRooms(room, sessions, trackInfo) {
       end : moment(session.end_time).utcOffset(4).format('HH:mm'),
       title: session.title,
       description: session.long_abstract,
-      session_id: session.id
+      session_id: session.id,
+      speakers_list: session.speakers.map((speaker) => speakersMap.get(speaker.id)),
+      tracktitle: tracktitle,
+      sessiondate: moment(session.start_time).format('dddd, Do MMM'),
+      roomname: roomName
 
     });
 

--- a/src/backend/fold.js
+++ b/src/backend/fold.js
@@ -60,7 +60,7 @@ function foldByTrack(sessions, speakers, trackInfo, reqOpts) {
       track = {
         title: session.track.name,
         color: returnTrackColor(trackDetails, (session.track == null) ? null : session.track.id),
-        date: moment(session.start_time).format('ddd, Do MMM'),
+        date: moment(session.start_time).format('dddd, Do MMM'),
         slug: slug,
         sessions: []
       };

--- a/src/backend/generator.js
+++ b/src/backend/generator.js
@@ -52,7 +52,7 @@ function transformData(sessions, speakers, event, sponsors, tracksData, roomsDat
   const eventurls = fold.extractEventUrls(event, speakers, sponsors, reqOpts);
   const copyright = fold.getCopyrightData(event);
   const sponsorpics = fold.foldByLevel(sponsors, reqOpts);
-  const roomsinfo  =  fold.foldByRooms(roomsData, sessions, tracksData);
+  const roomsinfo  =  fold.foldByRooms(roomsData, sessions, speakers, tracksData);
   const speakerslist = fold.foldBySpeakers(speakers, sessions, tracksData, reqOpts);
   const apptitle = fold.getAppName(event);
   

--- a/src/backend/templates/rooms.hbs
+++ b/src/backend/templates/rooms.hbs
@@ -67,15 +67,85 @@
             </div>
               <div class="eventtime col-xs-4 col-sm-4 col-md-2">
 
-                <span class="time-track">{{start}} - {{end}}</span>
+                <span class="time-track">{{start}}</span>
               </div>
+               <div class="room-container row"
+              data-toggle="collapse"
+              data-target="#desc-{{session_id}} .collapse"
+              aria-expanded="false"
+              aria-controls="desc-{{session_id}}">
               <div class="left-border col-xs-8 col-sm-8 col-md-9">
               
                 <h4 style="background-color:{{{color}}}"  class="sizeevent event">
                   {{title}}
                 </h4>
-            
+               <div  id="desc-{{session_id}}">
+                  <p class="collapse">
+                    <span class="tip-description">{{{description}}}
+                    </span>
+                  </p>
+                  <hr style="clear:both" class="collapse">
+                  <div class="session-speakers-list collapse">
+                    {{#speakers_list}}
+                    <p class="session-speakers-less">
+                      {{#if photo}}
+                      <p style="margin-right:20px" class="session-speakers">
+                        <img  onError="this.onerror=null;this.src='./dependencies/avatar.png';" class="card-img-top" src="{{photo}}" style="width:10rem; height:10rem; border-radius:50%;"/>
+                       </p>
+                      {{/if}}
+                       {{#if long_biography}}
+                      <span class="blacktext ">About {{name}}:</span>
+                    </p>
+                    <div class="session-speakers-more">
+                      <p>
+                        <span class="blacktext tip-description">{{{long_biography}}}</span>
+                      </p>
+                      <p class="blacktext session-speaker-social">
+                      {{#if web}}
+                        <a class="blacktext social speaker-social" href="{{{web}}}"}>
+                          <i class="fa fa-home"></i> Web
+                        </a>&nbsp;
+                      {{/if}}
+                      {{#if github}}
+                        <a class="blacktext  social speaker-social" href="{{{github}}}"}>
+                          <i class="fa fa-github"></i> Github
+                        </a>&nbsp;
+                      {{/if}}
+                      {{#if twitter}}
+                        <a class="blacktext  social speaker-social" href="{{{twitter}}}"}>
+                          <i class="fa fa-twitter"></i> Twitter
+                        </a>&nbsp;
+                       {{/if}}
+                       {{#if linkedin}} 
+                        <a class="blacktext  social speaker-social" href="{{{linkedin}}}"}>
+                          <i class="fa fa-linkedin"></i> LinkedIn
+                        </a>
+                        {{/if}}
+                         <hr style="clear:both">
+                      </p>
+                    </div>
+                    {{/if}}
+                    {{/speakers_list}}
+                    <div class="blacktext">
+                    {{#if roomname}}
+                    <p><i>{{roomname}}</i></p>
+                    {{/if}}
+                    {{#if sessiondate}}
+                    <p> {{sessiondate}}, <span>{{start}} - {{end}}</span></p>
+                    {{/if}}
+                    <p> 
+                    <ul class="title-inline">
+                      <li  style="background-color:{{{color}}}" class="titlecolor"></li>&nbsp;
+                      <li class="blacktext">{{tracktitle}}</li>
+                    </ul>
+                    </p><br>
+                    </div>
+                  </div>
+                </div>
+
               </div>
+              
+             </div> 
                {{/sessions}}
             </div>
               

--- a/src/backend/templates/rooms.hbs
+++ b/src/backend/templates/rooms.hbs
@@ -39,19 +39,25 @@
   <div class="container">
     <div  style="margin-top:4%" class="main row">
       <div class="col-md-12">
-        <h2 class="filter-heading text-center">
+        <h2 style="margin-bottom:40px;" class="filter-heading text-center">
          <span>
           <span>
             Venue
           </span>
           </span>
         </h2>
+
+    <div id="session-list" class="container">
+      {{#days}}
+          <span class="date-pill"><a href="./rooms.html#{{caption}}"> {{caption}} </a></span>
+        {{/days}}
         <div class="row">
         <div class="col-md-10">
-          <div id="track-list">
+          <div style="margin-top:4%" id="track-list">
             {{#roomsinfo}}
             <div class="row">
               <div style="padding:0" class="col-md-12">
+              <a class="anchor" id="{{date}}"></a>
               <h5 class="text">{{date}}</h4>
               </div>
                 
@@ -65,7 +71,7 @@
                {{/if}} 
               </div>
             </div>
-              <div class="eventtime col-xs-4 col-sm-4 col-md-2">
+              <div class="eventtime col-xs-2 col-sm-4 col-md-2">
 
                 <span class="time-track">{{start}}</span>
               </div>
@@ -74,7 +80,7 @@
               data-target="#desc-{{session_id}} .collapse"
               aria-expanded="false"
               aria-controls="desc-{{session_id}}">
-              <div class="left-border col-xs-8 col-sm-8 col-md-9">
+              <div class="left-border col-xs-10 col-sm-10 col-md-9">
               
                 <h4 style="background-color:{{{color}}}"  class="sizeevent event">
                   {{title}}
@@ -93,9 +99,9 @@
                         <img  onError="this.onerror=null;this.src='./dependencies/avatar.png';" class="card-img-top" src="{{photo}}" style="width:10rem; height:10rem; border-radius:50%;"/>
                        </p>
                       {{/if}}
-                       {{#if long_biography}}
                       <span class="blacktext ">About {{name}}:</span>
                     </p>
+                  {{#if long_biography}}
                     <div class="session-speakers-more">
                       <p>
                         <span class="blacktext tip-description">{{{long_biography}}}</span>

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -105,7 +105,7 @@ describe('fold', function() {
   });
   describe('.foldByRooms()', function () {
     it('should return sessions grouped by rooms', function () {
-      const roomData = fold.foldByRooms(data.microlocations.json, data.sessions.json, data.tracks.json);
+      const roomData = fold.foldByRooms(data.microlocations.json, data.sessions.json, data.speakers.json, data.tracks.json);
       //sassert.equal(roomData[0].hall, 'Dalton Hall');
     })
   });


### PR DESCRIPTION
 
ISSUE #671  #587
 -  [x] Added date top links (like in tracks page)
 -  [x] Added expanded session info on click (like in tracks page)
  - [x] time format - it should be the same as on tracks page
![7](https://cloud.githubusercontent.com/assets/12194719/17909616/e4874bea-69a2-11e6-9eb0-2f2fc7832fb5.png)
![67](https://cloud.githubusercontent.com/assets/12194719/17909632/ef6592ce-69a2-11e6-948c-4f8d01b9a1f1.png)
