### PR TITLE
Speaker page design Fixes

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -476,6 +476,10 @@ a {
         padding:2%;
         margin:10px;
         word-wrap: break-word;
+        line-height: 20px;
+        font-weight: 400;
+        color: $gray-dark;
+        text-align: justify;
       }
       .pop-footer {
         border-top-left-radius: 5px;

--- a/src/backend/templates/rooms.hbs
+++ b/src/backend/templates/rooms.hbs
@@ -53,7 +53,7 @@
 
     <div id="session-list" class="container">
       <div class="row">
-        <div class="col-md-10">
+        <div style="margin:15px;" class="col-md-10">
           <div style="margin-top:4%" id="track-list">
             {{#roomsinfo}}
             <div class="row">

--- a/src/backend/templates/speakers.hbs
+++ b/src/backend/templates/speakers.hbs
@@ -137,7 +137,7 @@
             </div>
           </div>
       <span class="speaker-name">{{{name}}}</span>
-      <p style="text-align:center; height:10px;">{{{organisation}}}</p>
+      <span class="speaker-name">{{{organisation}}}</p>
       </div>
     </div>
     {{/speakerslist}}


### PR DESCRIPTION
- [x] Make org and name font-size equal 
- [x]  Make description gray
- [x]  Content Align left
- [x] Room page pills adjusted

![8](https://cloud.githubusercontent.com/assets/12194719/18029627/ca7c992e-6cba-11e6-9903-cebcfed60862.png)

![7](https://cloud.githubusercontent.com/assets/12194719/18029639/1c231e42-6cbb-11e6-82a3-0ea7f28c714c.png)
