### PR TITLE
Fix erroneous Line Breaks in Track Info Areas

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -636,6 +636,12 @@ a {
     height: 12px;
     border-radius: 50%;
   }
+
+.titletext {
+  vertical-align: top;
+  width: 140px;
+}
+
   .title-inline { 
     padding:0;
     li{

--- a/src/backend/templates/rooms.hbs
+++ b/src/backend/templates/rooms.hbs
@@ -162,7 +162,7 @@
          
             <ul class="title-inline">
               <li  style="background-color:{{{color}}}" class="titlecolor"></li>
-              <li>{{title}}</li>
+              <li class="titletext">{{title}}</li>
             </ul>
           
         {{/if}}


### PR DESCRIPTION
Tries to fix #700 . 

The bug mentioned in the issue #700 was occurring because no explicit width was mentioned for the inline block. A new css class `titletext` is added to fix the issue. 140px was the maximum size i could go with, from 141px onwards the line breaks occur again.

***Before :*** 
![selection_002](https://cloud.githubusercontent.com/assets/13910561/18030262/0b5fdf4e-6c9f-11e6-9038-c7bbbca61bfe.png)


***After :***
![selection_001](https://cloud.githubusercontent.com/assets/13910561/18030261/0b3879c2-6c9f-11e6-9fa6-4af08e72e00a.png)

