### PR TITLE
Footer: Align location icon and address info on same line

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -1194,6 +1194,11 @@ a {
             left: 8px; 
           }
         }
+        .address {
+          span {
+            vertical-align: top;
+          }
+        }
       }
     }
 

--- a/src/backend/templates/partials/footer.hbs
+++ b/src/backend/templates/partials/footer.hbs
@@ -48,7 +48,7 @@
         </li>
         {{/if}}
         {{#if eventurls.location}}
-        <li>
+        <li class="address">
         <i class="fa fa-map-marker"></i>  
           <span>{{{eventurls.orgname}}}&#44;&nbsp;{{eventurls.location}}</span>        
         </li>


### PR DESCRIPTION
@aayusharora 
Intends to resolve #716 .

Looks like this now : 

![selection_005](https://cloud.githubusercontent.com/assets/13910561/18034660/26048c26-6d32-11e6-8d9a-b688e6bdf0c5.png)
