### PR TITLE
padding adjustment roompage

### DIFF
--- a/src/backend/templates/rooms.hbs
+++ b/src/backend/templates/rooms.hbs
@@ -67,7 +67,7 @@
               <div class="row">
                 <div style="clear:both" class="col-md-12">
                 {{#if venue }}
-                <h5 class="text" style="padding-bottom:20px;">{{venue}}</h4>
+                <h5 class="text">{{venue}}</h4>
                 {{/if}} 
                 </div>
               </div>


### PR DESCRIPTION
Issue #723
I have find out very less difference between styling of left panel of Room and Schedule page. 
That was only padding.
The width of left panel for Schedule page is greater because Room page also contain Track bullets on right which requires their own space.
Corrected Padding here
![23](https://cloud.githubusercontent.com/assets/12194719/18036626/c06e032c-6d8d-11e6-9eb6-053281366391.png)

![24](https://cloud.githubusercontent.com/assets/12194719/18036628/ce13e154-6d8d-11e6-815d-49aa753dc8e9.png)
