### PR TITLE
Corrected Overlay

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -803,7 +803,6 @@ a {
   display: block;
   height: 262.5px;
   left: 0;
-  margin: 0 auto;
   opacity: 0;
   position: relative;
   top: 0;
@@ -909,6 +908,12 @@ a {
             }
 
           }
+          @media screen and (max-width: 892px) {
+            .hover-state {
+              margin: 0 auto;
+            }
+          }
+
         }
         .social-links {
           @include sociallinks;
@@ -991,7 +996,7 @@ a {
               position: absolute;
               top: 140%;
             } 
-          }   
+          } 
         }
       .background-image {
         height: 262.5px;
@@ -1057,6 +1062,21 @@ a {
     }
   }
 }
+
+@media screen and (max-width: 992px) {
+  .speaker-with-bio {
+    .speaker {
+      .image-holder {
+        .responsive-overlay {
+            .hover-state {
+              margin: 0 auto;
+            }
+        }
+      }
+    }
+  } 
+} 
+
 
 @media only screen and (min-width: 992px) and (max-width: 1200px) {
   .speaker-with-bio {


### PR DESCRIPTION
ISSUE #729
In the current hosted version, the overlay is disturbed. 
Before
![89](https://cloud.githubusercontent.com/assets/12194719/18047260/9113f4c6-6df9-11e6-8383-e89ed6457c44.png)
After
![90](https://cloud.githubusercontent.com/assets/12194719/18047261/911fd8d6-6df9-11e6-9340-eb3d4278c93c.png)

