### PR TITLE
Left panel Width corrected 

### DIFF
--- a/src/backend/templates/schedule.hbs
+++ b/src/backend/templates/schedule.hbs
@@ -61,7 +61,7 @@
         {{#times}}
 
         <div class="row">
-          <div class="eventtime col-xs-2 col-sm-2 col-md-2">
+          <div style="width: 13.88%;" class="schedule eventtime col-xs-2 col-sm-2 col-md-2">
           <span>{{caption}}</span>
           </div>
 

--- a/src/backend/templates/schedule.hbs
+++ b/src/backend/templates/schedule.hbs
@@ -61,7 +61,7 @@
         {{#times}}
 
         <div class="row">
-          <div style="width: 13.88%;" class="schedule eventtime col-xs-2 col-sm-2 col-md-2">
+          <div style="width: 13.88%;" class="eventtime col-xs-2 col-sm-2 col-md-2">
           <span>{{caption}}</span>
           </div>
 


### PR DESCRIPTION
Issue #723
![67](https://cloud.githubusercontent.com/assets/12194719/18056147/585e75aa-6e28-11e6-88cc-710511c91da4.png)

Both room and schedule left panel is 13.88% wider.