### PR TITLE
fix Tracks screen to work with unicode track names

### DIFF
--- a/src/backend/fold.js
+++ b/src/backend/fold.js
@@ -52,7 +52,7 @@ function foldByTrack(sessions, speakers, trackInfo, reqOpts) {
     const trackName = (session.track == null) ? 'deftrack' : session.track.name;
     const roomName = (session.microlocation == null) ? ' ' : session.microlocation.name;
     const session_type = (session.session_type == null) ? ' ' : session.session_type.name ;
-    const slug = date + '-' + slugify(trackName);
+    const slug = date + '-' + trackName;
     let track = null;
 
     // set up track if it does not exist

--- a/src/backend/fold.js
+++ b/src/backend/fold.js
@@ -61,6 +61,7 @@ function foldByTrack(sessions, speakers, trackInfo, reqOpts) {
         title: session.track.name,
         color: returnTrackColor(trackDetails, (session.track == null) ? null : session.track.id),
         date: moment(session.start_time).format('dddd, Do MMM'),
+        sortKey: moment(session.start_time).format('YY-MM-DD'),
         slug: slug,
         sessions: []
       };
@@ -106,7 +107,7 @@ function foldByTrack(sessions, speakers, trackInfo, reqOpts) {
 
   let tracks = Array.from(trackData.values());
 
-  tracks.sort(byProperty('date'));
+  tracks.sort(byProperty('sortKey'));
 
   return tracks;
 }
@@ -469,6 +470,7 @@ function foldByRooms(room, sessions, speakers, trackInfo) {
     if (!roomData.has(slug) && (session.microlocation != null)) {
       room = {
         date: moment(session.start_time).utcOffset(4).format('dddd, Do MMM'),
+        sortKey: moment(session.start_time).utcOffset(4).format('YY-MM-DD'),
         slug: slug,
         sessions: []
       };
@@ -518,7 +520,7 @@ function foldByRooms(room, sessions, speakers, trackInfo) {
 
   let roomsDetail = Array.from(roomData.values());
 
-  roomsDetail.sort(byProperty('date'));
+  roomsDetail.sort(byProperty('sortKey'));
 
   return roomsDetail;
 }


### PR DESCRIPTION
fix Tracks screen so that it's correctly displayed when track names are Unicode
the problem is that slugify() removes all non-ASCII characters - essentially making slug contain date only; as slug is used to only internally group sessions, removing slugify() call fixes the problem
