### PR TITLE
beautify speakers list without biographies

### DIFF
--- a/src/backend/templates/rooms.hbs
+++ b/src/backend/templates/rooms.hbs
@@ -90,18 +90,22 @@
                       </p>
                     <hr style="clear:both" class="collapse">
                       <div class="session-speakers-list collapse">
-                        {{#speakers_list}}
+                       {{#speakers_list}}
                        <a href="speakers.html#{{nameIdSlug}}">
                         <p class="session-speakers-less">
                           {{#if photo}}
                           <p style="margin-right:20px" class="session-speakers">
-                          <img  onError="this.onerror=null;this.src='./dependencies/avatar.png';" class="card-img-top" src="{{photo}}" style="width:10rem; height:10rem; border-radius:50%;"/>
+                           <img  onError="this.onerror=null;this.src='./dependencies/avatar.png';" class="card-img-top" src="{{photo}}" style="width:10rem; height:10rem; border-radius:50%;"/>
+                          </p>
+                          {{/if}}
+                          {{#if long_biography}}
+                          <span class="graytext ">About {{name}}:</span>
+                          {{else}}
+                          <span class="graytext ">{{name}}</span>
+                          {{/if}}
                         </p>
-                        {{/if}}
-                      <span class="graytext ">About {{name}}:</span>
-                    </p>
                       </a>
-                  {{#if long_biography}}
+                    {{#if long_biography}}
                     <div class="session-speakers-more">
                       <p>
                         <span class="blacktext tip-description">{{{long_biography}}}</span>
@@ -127,10 +131,10 @@
                           <i class="fa fa-linkedin"></i> LinkedIn
                         </a>
                         {{/if}}
-                         <hr style="clear:both">
                       </p>
                     </div>
                     {{/if}}
+                    <hr style="clear:both">
                     {{/speakers_list}}
                     <div class="blacktext">
                     {{#if roomname}}


### PR DESCRIPTION
For speakers that lack biographies:
- change `"About <speaker name>:"` to `"<speaker name>"`
- make horizontal separator below the speaker visible