### PR TITLE
Schedule page redesign to use expandable blocks

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -673,7 +673,7 @@ a {
   }
 
 .title-legend {
-  left: 0;
+  left: 70px;
 }
 
 .track-names {
@@ -682,7 +682,7 @@ a {
 }
 
 @media (max-width: 990px) {
-  .title-inline {
+  .title-legend {
     float: left;
     width: 40%;
   }


### PR DESCRIPTION
resolves #764 
fixes broken display of track legend (at the bottom of the page) introduced by 99622d0