### PR TITLE
Fix tracks page speaker link

### DIFF
--- a/src/backend/templates/tracks.hbs
+++ b/src/backend/templates/tracks.hbs
@@ -31,7 +31,7 @@
       <![endif]-->
     </head>
     <body>
-      <a id="top"></a>  
+      <a id="top"></a>
       {{> navbar}}
 
 
@@ -45,14 +45,14 @@
         </h2>
       </div>
     </div>
-     
+
       <p class="date-list">
       {{#days}}
       <span class="date-pill"><a href="./tracks.html#{{firstSlug}}"> {{caption}} </a></span>
       {{/days}}
       </p>
-       
-    <div id="session-list" style="margin-top: 4%;" class="container">    
+
+    <div id="session-list" style="margin-top: 4%;" class="container">
       {{#tracks}}
       <div class="row">
         <div class="col-md-12">
@@ -112,7 +112,7 @@
                 </p>
                 {{#speakers_list}}
 
-                  {{#if photo}}  
+                  {{#if photo}}
                 <p style="margin-right:20px" class="session-speakers">
                         <a href="speakers.html#{{nameIdSlug}}">
                         <img  onError="this.onerror=null;this.src='./dependencies/avatar.png';" class="card-img-top" src="{{photo}}" style="width:5rem; height:5rem; border-radius:50%;"/>
@@ -122,7 +122,7 @@
                   {{/speakers_list}}
                   <ul style="padding:0">
                   {{#speakers_list}}
-                   <li><a href="speakers.html#{{id}}">
+                   <li><a href="speakers.html#{{nameIdSlug}}">
                    {{name}}
                    {{#if organisation}}
                    ({{organisation}})
@@ -164,12 +164,12 @@
                           <i class="fa fa-twitter"></i> Twitter
                         </a>
                        {{/if}}
-                       {{#if linkedin}} 
+                       {{#if linkedin}}
                         <a class="social speaker-social" href="{{{linkedin}}}"}>
                           <i class="fa fa-linkedin"></i> LinkedIn
                         </a>
                         {{/if}}
-                        
+
                       </p>
                     </div>
                     {{/if}}
@@ -187,7 +187,7 @@
     </div>
    </div>
     {{> footer}}
-  
+
 
     <script src="./dependencies/jquery.min.js"></script>
     <script src="./dependencies/bootstrap.min.js" type="text/javascript"></script>
@@ -205,6 +205,6 @@
         });
       });
     </script>
- 
+
 </body>
 </html>


### PR DESCRIPTION
This PR fixes issue #789 by changing the link to use nameIdSlug instead of id.

Oh, and my text editor removes trailing whitespaces. Should I just leave it there or remove it (like the changes in this PR)