### PR TITLE
Schedule Page: Fix Box area not always linkified.

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -701,7 +701,8 @@ a {
   }
 
 .title-legend {
-  left: 50px;
+  float: right;
+  width: 215px;
 }
 
 .track-names {


### PR DESCRIPTION
Tries to resolve #800 .
Here is the result:

![screenshot from 2016-09-13 06-37-05](https://cloud.githubusercontent.com/assets/13910561/18458420/a95f92e8-797e-11e6-83cb-76a8dc027195.png)
P.S screenshot shows width as 225px while it has been kept 215px in the code.
