### PR TITLE
Width of map and contact details changed

### DIFF
--- a/src/backend/templates/event.hbs
+++ b/src/backend/templates/event.hbs
@@ -192,9 +192,9 @@
 {{#if eventurls.longitude}}
 <div style="background:#f5f5f5">
     <div style="margin-right:0;margin-left:0;" class="row">
-      <div class="col-md-6" id="map">
+      <div class="col-md-8" id="map">
       </div>
-      <div style="margin-top:20px;" class="col-md-6">
+      <div style="margin-top:20px;" class="col-md-4">
       {{#if eventurls.location}}
        <h4> Address </h4>
        <p>{{eventurls.location}}</p>


### PR DESCRIPTION
Changed the width of map to col-md-8 and contact details to col-md-4,  looks more clean than earlier, there is a lot a whitespace towards the right of contact details unused.