### PR TITLE
Auto-deploy to gh-pages on each commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ script:
   - istanbul cover _mocha
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash cli.sh; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash gh_deploy.sh; fi'
 deploy:
   provider: heroku
   api_key:

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,25 @@
+"use strict";
+var fs = require('fs');
+var io = require('socket.io-client');
+var request = require('request');
+
+var client = io.connect('http://127.0.0.1:5000');
+var i = 1;
+client.on('connect', function () {
+
+    if (i == 1) {
+        i = 0;
+        var data = {
+            name: 'testapp',
+            email: 'a@a.com',
+            theme: 'light',
+            datasource: 'eventapi',
+            assetmode: 'download',
+            apiendpoint: process.env.GH_ENDPOINT
+        }
+        client.emit('live', data);
+    }
+    client.close();
+});
+
+

--- a/cli.sh
+++ b/cli.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -o errexit -o nounset
+
+GH_TIMEOUT="${GH_TIMEOUT:-120s}"
+
+node cli.js & timeout $GH_TIMEOUT npm run start;

--- a/gh_deploy.sh
+++ b/gh_deploy.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -o errexit -o nounset
+
+if [ "$TRAVIS_BRANCH" != "development" ]
+then
+  echo "This commit was made against the $TRAVIS_BRANCH and not the master! No deploy!"
+  exit 0
+fi
+
+rev=$(git rev-parse --short HEAD)
+
+cd dist/a@a.com/testapp
+
+git init
+git config user.name "shubham-padia"
+git config user.email "shubhamapadia@gmail.com"
+
+git remote add upstream "https://$GH_TOKEN@github.com/shubham-padia/open-event-webapp.git"
+git fetch upstream
+git reset upstream/gh-pages
+
+touch .
+
+git add -A .
+git commit -m "rebuild pages at ${rev}"
+git push -q upstream HEAD:gh-pages


### PR DESCRIPTION
Tries to resolve #724 and #727 .
For this to work, The sample should be published on open-event orga server,
 you would have to set the following variables in Travis repository settings.

- `GH_TOKEN`: Github access token for the repo (for more refer [here](https://help.github.com/articles/creating-an-access-token-for-command-line-use/)
- `GH_ENDPOINT`: API endpoint of the sample event present on the orga server (right now you can use http://open-event-dev.herokuapp.com/api/v2/events/189 which is according to the latest sample) 
- `SENDGRID_API_KEY` if not set already
- `GH_TIMEOUT`( optional, default: 120s ): The maximum time for which the the server + cli are allowed to run. Recommended 60s. 