### PR TITLE
Fixing border corners issue in speaker popups

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -540,6 +540,7 @@ a {
   .pop {
     background-color: $white;
     margin-left: 20px;
+    border-radius: 3px;
 
     a {
       margin-left: -5px;
@@ -562,8 +563,8 @@ a {
   .pop-header {
     background: $span-background;
     border-bottom: 1px solid $gray-perfect;
-    border-top-left-radius: 5px;
-    border-top-right-radius: 5px;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
     height: 35px;
     margin-left: -20px;
     padding-bottom: 0;


### PR DESCRIPTION
From #833 by @mariobehling 
`Thank you. On the top right and bottom right, the corner lines are still not completely closed. Is is possible to fix this?`

This pull request fixes that corners issue and small whitespace inside border corners.

<img width="716" alt="screen shot 2016-10-09 at 6 10 58 pm" src="https://cloud.githubusercontent.com/assets/1812082/19220489/c9f18ffc-8e4b-11e6-98a6-6c86de5ba2a6.png">
