### PR TITLE
Add buildlogger.js description

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The webapp generator uses the following technologies -
  - [dist.js](/src/backend/dist.js) - Creates folders, cleans folders, unzips/zips packages
  - [ftpdeploy.js](/src/backend/ftpdeploy.js) - Deploys finished website to organiser's server (optional)
  - [mailer.js](/src/backend/mailer.js) - Sends mail to organiser notifying of successful creation
+ - [buildlogger.js](/src/backend/buildlogger.js) - Displays build logs while generating webapp
  
 4. Templates
 


### PR DESCRIPTION
This is for the GCI task: https://codein.withgoogle.com/dashboard/task-instances/6327549833510912/. I added buildlogger.js in the main documentation.