### PR TITLE
Changing Documentation on Installation on Local Machines

### DIFF
--- a/docs/INSTALLATION_LOCAL.md
+++ b/docs/INSTALLATION_LOCAL.md
@@ -29,4 +29,4 @@ Note : If you are running the app behind a proxy, set the proxy option in config
 | Node.js |  | v4.0 (or above) |
 | Browser | Firefox/Chrome/Safari | 21+/11+/9+
 
-Note: Computers running on Windows OS may encounter problems when installing the Webapp Generator on local machines. As Windows does not come bundled with a C++ compiler, which is needed in npm install, the command prompt may throw up a error which states that `node-gyp rebuild` fails on yor system. Hence it is advised a further prerequisite (for Windows users) is to download Visual Studio Community 2015 which contains a C++ compiler (link is https://www.visualstudio.com/downloads/)
+Note: Computers running on Windows OS may encounter problems when installing the Webapp Generator on local machines. As Windows does not come bundled with a C++ compiler, which is needed in NodeJS, the command prompt may throw up a error which states that `node-gyp rebuild` fails on yor system. Hence it is advised a further prerequisite (for Windows users) is to download Visual Studio Community 2015 which contains a C++ compiler (link is https://www.visualstudio.com/downloads/)

--- a/docs/INSTALLATION_LOCAL.md
+++ b/docs/INSTALLATION_LOCAL.md
@@ -29,3 +29,4 @@ Note : If you are running the app behind a proxy, set the proxy option in config
 | Node.js |  | v4.0 (or above) |
 | Browser | Firefox/Chrome/Safari | 21+/11+/9+
 
+Note: Computers running on Windows OS may encounter problems when installing the Webapp Generator on local machines. As Windows does not come bundled with a C++ compiler, which is needed in npm install, the command prompt may throw up a error which states that `node-gyp rebuild` fails on yor system. Hence it is advised a further prerequisite (for Windows users) is to download Visual Studio Community 2015 which contains a C++ compiler (link is https://www.visualstudio.com/downloads/)


### PR DESCRIPTION
The documentation to installing the Webapp Generator on local machines has been changed in order to address errors Windows users face when setting up the website.