### PR TITLE
Actually terminate zip on clicking the X button

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -39,7 +39,14 @@ io.on('connection', function(socket){
     })
   });
   uploader.on('start', function(event) {
-    generator.startZipUpload(event.file)
+    generator.startZipUpload(event.file);
+    socket.on('Cancel', function(msg) {
+        if(event.file.success == 1) {
+            return; // file has already been fully transfered so no point of aborting
+        }
+        console.log(msg);
+        uploader.abort(event.file.id, socket);
+    });
   });
 
   socket.on('live', function(formData) {

--- a/src/app.js
+++ b/src/app.js
@@ -41,11 +41,11 @@ io.on('connection', function(socket){
   uploader.on('start', function(event) {
     generator.startZipUpload(event.file);
     socket.on('Cancel', function(msg) {
-        if(event.file.success == 1) {
-            return; // file has already been fully transfered so no point of aborting
-        }
-        console.log(msg);
-        uploader.abort(event.file.id, socket);
+      if(event.file.success === true) {
+        return; // file has already been fully transfered so no point of aborting
+      }
+      console.log(msg);
+      uploader.abort(event.file.id, socket);
     });
   });
 

--- a/src/www/js/form.js
+++ b/src/www/js/form.js
@@ -23,6 +23,7 @@ $(document).ready(function () {
     e.preventDefault();
     $('#siofu_input').val('').show()
     $('#upload-info').hide();
+    socket.emit('Cancel', 'Terminate the zip upload');
     updateGenerateProgress(0);
   })
 


### PR DESCRIPTION
Fixes the issue #959. Uploading zip files were not getting canceled on clicking the X button. The progress bar was retracting but the actual uploading of the zips continued in the background. So if the user tried to upload another zip, then it won't get uploaded until the first one has finished. 

I have made two videos to demonstrate this issue

* Before the changes
https://www.opentest.co/share/c6365830d5c611e6a7cb6f2926412bab
* After the changes
https://www.opentest.co/share/a49ba540d5cb11e68531cf81a6426bba
@mariobehling @aayusharora Please review.