### PR TITLE
Fixes #973: Layout of input field text on safari

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -1224,6 +1224,10 @@ a {
     font-family: sans-serif;
   }
 
+  input {
+    line-height: 24px;
+  }
+
   @media only screen and (max-width: 600px) {
     float: none;
 


### PR DESCRIPTION
Earlier the placeholder text along with the input text in the search box , was oddly displaced towards bottom of the text field in safari browser. This resolves  that 

Before :
![image](https://cloud.githubusercontent.com/assets/17252805/21905238/ba9e2f0c-d92c-11e6-87ee-20bedc22654d.png)

After :
![image](https://cloud.githubusercontent.com/assets/17252805/21905356/213473c0-d92d-11e6-8729-324103bb64d5.png)

@Princu7 Please review.