### PR TITLE
Add unit test to confirm the generation of the event site

### DIFF
--- a/src/backend/buildlogger.js
+++ b/src/backend/buildlogger.js
@@ -3,12 +3,19 @@ var exports = module.exports = {};
 var buildLog = [];
 
 exports.addLog = function(type, smallMessage, socket, largeMessage) {
-    if (typeof(largeMessage) === 'undefined') {
-        largeMessage = smallMessage;
-    }
+  if (typeof(largeMessage) === 'undefined') {
+    largeMessage = smallMessage;
+  }
 
-    buildLog.push({'type':type, 'smallMessage' : smallMessage, 'largeMessage': largeMessage});
-    largeMessage = largeMessage.toString();
-    var obj = {'type' : type, 'smallMessage' : smallMessage, 'largeMessage': largeMessage};
+  buildLog.push({'type':type, 'smallMessage' : smallMessage, 'largeMessage': largeMessage});
+  largeMessage = largeMessage.toString();
+  var obj = {'type' : type, 'smallMessage' : smallMessage, 'largeMessage': largeMessage};
+  var emit = false;
+
+  if (socket.constructor.name === 'Socket') {
+    emit = true;
+  }
+  if (emit) {
     socket.emit('buildLog', obj);
+  }
 };

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -138,3 +138,25 @@ describe('app',  () =>  {
   })
 });
 
+describe('generate', function() {
+  describe('.createDistDir()', function() {
+    this.timeout(200000);
+
+    it('should generate the event site', function(done) {
+      var data = {}
+      data.body = {
+        "email": "princu7@gmail.com",
+        "name": "Open Event",
+        "apiendpoint": "https://raw.githubusercontent.com/fossasia/open-event/master/sample/FOSSASIA14/",
+        "datasource": "eventapi",
+        "assetmode" : "download"
+      }
+
+      generator.createDistDir(data, 'Socket', function(appFolder) {
+        assert.equal(appFolder, "princu7@gmail.com/FOSSASIA 2014");
+        done();
+      });
+
+    });
+  });
+});


### PR DESCRIPTION
Adds unit-test for confirmation whether the event site is being generated or not. In the past, there have been any instances where the tests pass successfully but the app generator stuck in the middle while generating the event site. This test aims to ensure that the whole event site is being generated. 

I will be adding more unit tests. This was a major critical test so added it first.
@aayusharora @mariobehling Please review. Thanks! :)