### PR TITLE
Fixes buggy speaker dialog on smaller dialogs

### DIFF
--- a/src/backend/assets/js/popover.js
+++ b/src/backend/assets/js/popover.js
@@ -31,9 +31,17 @@ $(document).ready(function () {
       popbox = $(".pop-box");
       preserve3d= $(".preserve3d");
       widthWindow = $(window).width();
+      openflag = 0;
   if( widthWindow < 768) {
     $(document).on('click','.image-holder',function (event) {
+      if(openflag === 0) {
        addOverlay(event);
+       openflag = 1;
+      }
+     else {
+      removeOverlay(event)
+      openflag = 0;
+    }
     });
   }
   else {


### PR DESCRIPTION
fixes #978 
![giphy 1](https://cloud.githubusercontent.com/assets/17252805/23100427/3486a150-f6a6-11e6-829b-cdff59210c58.gif)

Now the dialog disappears once the user clicks on the speaker again.
Please review @Princu7 @aayusharora 