### PR TITLE
Use underscore instead of + in the zip file name

### DIFF
--- a/src/backend/mailer.js
+++ b/src/backend/mailer.js
@@ -114,6 +114,7 @@ function emailSend(toEmail, url, appName) {
 
 function uploadAndsendMail(toEmail, appName, socket, done) {
   const file = distHelper.distPath + '/' + toEmail + '/event.zip';
+  appName = appName.split(' ').join('_');
   const fileName = uuid.v4() + '/' + appName + '.zip';
 
   uploadToS3(file, fileName, socket)


### PR DESCRIPTION
Fixes #1066 properly. 
In the previous request, the name of the zip file was like `FOSSASIA+Summit`. Changed that to like this `FOSSASIA_Summit`. Sorry. Kindly review again. Thanks
* Test Server
http://secure-meadow-20680.herokuapp.com/