### PR TITLE
Removes bold text and line breaks

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -1080,7 +1080,7 @@ a {
       overflow-y: overlay;
     }
 
-    span {
+    .sub {
       display: inline-block;
       font-weight: 600;
       margin-bottom: 18px;


### PR DESCRIPTION
 Fixes #1121 
Removes bold text and line breaks from featured speakers section.

Screenshot : 
![screen shot 2017-03-05 at 6 47 03 pm](https://cloud.githubusercontent.com/assets/12807846/23587937/7e239a6c-01db-11e7-9881-e7181cf674c4.png)

Demo link :
https://geekyd.github.io/eventApplication/

@mariobehling @aayusharora @Princu7 Please review. Thanks :)
