### PR TITLE
Fixed issue #1100 : space removed if speaker has no orga

### DIFF
--- a/src/backend/templates/rooms.hbs
+++ b/src/backend/templates/rooms.hbs
@@ -123,9 +123,7 @@
 		             	{{/speakers_list}}
 		             	<ul style="padding:0;font-size:15px;">
 		             	  {{#speakers_list}}
-		             	    {{name}}
-		             	    {{#if organisation}}
-                        ({{organisation}}){{/if}}{{#if @last}}{{else}},{{/if}}
+		             	    {{name}}{{#if organisation}}({{organisation}}){{/if}}{{#if @last}}{{else}},{{/if}}
 		             	 {{/speakers_list}}
 		             	</ul>
 		             	<ul style="padding:0;font-size:15px;">

--- a/src/backend/templates/tracks.hbs
+++ b/src/backend/templates/tracks.hbs
@@ -116,8 +116,7 @@
 		             	            {{/speakers_list}}
 		             	            <ul style="padding:0;font-size:15px;">
                                         {{#speakers_list}}
-                                            {{name}}
-                                            {{#if organisation}}({{organisation}}){{/if}}{{#if @last}}{{else}},{{/if}}
+                                            {{name}}{{#if organisation}}({{organisation}}){{/if}}{{#if @last}}{{else}},{{/if}}
                                         {{/speakers_list}}
 		             	            </ul>
 		             	            <ul style="padding:0;font-size:15px;">


### PR DESCRIPTION
I have edited the api zip to have 2 speakers on same track(on 2 tracks) and removed organisation in one of the speaker.
 The live preview can be seen here :- 
https://rishabhk07.github.io/open-gh/tracks.html
