### PR TITLE
Convert the speakers images into jpg format and reduce size

### DIFF
--- a/src/backend/dist.js
+++ b/src/backend/dist.js
@@ -96,6 +96,15 @@ const downloadJson = function(appPath, endpoint, jsonFile, cb) {
 
 };
 
+var extensionChange = function(image) {
+  var name = image.substring(0, image.lastIndexOf('.'));
+  var extension = image.substring(image.lastIndexOf('.') + 1);
+  if(extension === 'jpg') {
+    return image + '.new';  
+  }
+  return name + '.jpg';
+};
+
 var resizeSponsors = function(dir, socket, done) {
   fs.readdir(dir + '/sponsors/', function(err, list){
     if(err) {
@@ -127,7 +136,7 @@ var resizeSponsors = function(dir, socket, done) {
       done();
     });
   });
-};
+}; 
 
 var resizeSpeakers = function(dir, socket, done) {
   fs.readdir(dir + '/speakers/', function(err, list){
@@ -139,18 +148,27 @@ var resizeSpeakers = function(dir, socket, done) {
         .resize(300, 300)
         .background({r: 255, g: 255, b: 255, a: 0})
         .embed()
-        .toFile(dir + '/speakers/' + image + '.new', (err) => {
+        .toFile(dir + '/speakers/' + extensionChange(image), (err) => {
           if(err) {
-            console.log(image + 'can not be converted');
             console.log(err);
             trial(null);
             return 0;
           }
-
-          fs.rename(dir + '/speakers/' + image + '.new' , dir + '/speakers/' + image , function(err) {
-            if ( err ) console.log('ERROR: ' + err);
+          var extension = image.substring(image.lastIndexOf('.') + 1);
+          if(extension === 'jpg') {
+            fs.rename(dir + '/speakers/' + image + '.new', dir + '/speakers/' + image, function(err) {
+              if(err) {
+                console.log(err);
+              }
+              trial(null);
+            });
+          }
+          else {
+            fs.unlink(dir + '/speakers/' + image, function(err) {
+              if ( err ) console.log('ERROR: ' + err);
+            });
             trial(null);
-          });
+          }
         });
     }, function(err) {
       console.log("Speakers images converted successfully");
@@ -164,6 +182,7 @@ module.exports = {
   uploadsPath,
   resizeSponsors,
   resizeSpeakers,
+  extensionChange,
   moveZip: function(dlPath, id) {
     fs.move(dlPath, path.join(__dirname, "../../uploads/connection-" + id.toString() + "/upload.zip"), () => {
 

--- a/src/backend/fold.js
+++ b/src/backend/fold.js
@@ -678,18 +678,21 @@ function foldBySpeakers(speakers ,sessions, tracksData, reqOpts, next) {
         if (speaker.photo.substring(0, 4) === 'http') {
           distHelper.downloadSpeakerPhoto(appFolder, speaker.photo, function(result){
             speakers[key].photo = encodeURI(result);
+            speakers[key].photo = speakers[key].photo.substring(0, speakers[key].photo.lastIndexOf('.')) + '.jpg';
             callback();
           });
         }
         else if (reqOpts.datasource === 'eventapi' ) {
           distHelper.downloadSpeakerPhoto(appFolder, urljoin(reqOpts.apiendpoint, speaker.photo), function(result){
             speakers[key].photo = encodeURI(result);
+            speakers[key].photo = speakers[key].photo.substring(0, speakers[key].photo.lastIndexOf('.')) + '.jpg';
             callback();
           });
         } else {
           var reg = speaker.photo.split('');
           if(reg[0] =='/'){
             speakers[key].photo = encodeURI(speaker.photo.substring(1,speaker.photo.length));
+            speakers[key].photo = speakers[key].photo.substring(0, speakers[key].photo.lastIndexOf('.')) + '.jpg';
             callback();
           }
         }


### PR DESCRIPTION
Fixes #1123.
* The speaker images are now being converted to jpg instead of png.
* The size of the zip has reduced significantly by over 60%

Test Server:
http://secure-meadow-20680.herokuapp.com/