### PR TITLE
#1145 : make search bar full width on small screens

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -1329,7 +1329,7 @@ a {
   }
 
   @media only screen and (max-width: 600px) {
-    display: inline-block;
+    display: inline;
     float: none;
     width: 40%;
 


### PR DESCRIPTION
Solves: #1145

Made the search bar appear full width for small screens like mobile. This is how it looks now :-

![fossasia](https://cloud.githubusercontent.com/assets/17925669/23783202/c9a921a8-057f-11e7-9786-24816c061ed8.png)
