### PR TITLE
Move time-info to very left for small screens

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -693,6 +693,12 @@ a {
   vertical-align: middle;
 }
 
+@media only screen and (max-width: 600px) {
+  .eventtime {
+    padding-left: 0px;
+  }
+}
+
 .sesroom {
   color: $white;
   padding: 1%;


### PR DESCRIPTION
Issue #1144 Removed the indent on mobile views for left-time columns. Aligned it to the main container.
![screenshot from 2017-03-13 17-11-05](https://cloud.githubusercontent.com/assets/10852939/23854044/8ed51d50-0815-11e7-9cbd-e5dd9e40b468.png)
