### PR TITLE
Corrects the title message on deployment page when the user press the

### DIFF
--- a/src/www/js/deployProgress.js
+++ b/src/www/js/deployProgress.js
@@ -7,6 +7,7 @@ var $error = $('#error');
 var $progressBar = $('#upload-progress-bar');
 var $progressVal = $('#upload-progress-val');
 var $progressDiv = $('.progress');
+var $title = $('#title');
 
 function resetContents() {
   $error.html('');
@@ -47,6 +48,7 @@ $deploy.click(function() {
   showInfo();
   $deploy.hide();
   $abort.show();
+  $title.html('Press the button below to abort the deployment process');
 });
 
 $abort.click(function() {
@@ -95,4 +97,5 @@ socket.on('abort', function(msg) {
   $deploy.show();
   $error.html("");
   addErrorMessage(msg);
+  $title.html('Press the button below to re-start the deployment process');
 });


### PR DESCRIPTION
deploy button. Partially resolves #1162.

* When the user clicks on the Deploy button, the text of the title now changes from 'Press the button below to deploy' to 'Press the button below to abort the process'.

* When the user presses the abort button, the text of the title now changes from 'Press the button below to abort the process' to 'Press the button below to re-start the deployment process'.

* Test Server:
http://secure-meadow-20680.herokuapp.com