### PR TITLE
Fixes the speakers sessions in speakers and session description in tr…

### DIFF
--- a/src/backend/assets/js/popover.js
+++ b/src/backend/assets/js/popover.js
@@ -9,12 +9,6 @@ $(document).ready(function () {
       speakerinfo = $(".speaker-info");
 
   popbox.addClass('hide');
-  if( widthWindow < 768) {
-    $(document).on('click','.sizeevent',function (event) {
-      popBox(event);
-    });
-  }
-  else {
     headerpop.hover(function (event) {
       popBox(event);
     },function(){
@@ -22,7 +16,6 @@ $(document).ready(function () {
       hidePopbox();
       hideUnderline();
     });
- }
 
   let imageholder = $(".image-holder"),
       speaker = $(".speaker"),

--- a/src/backend/fold.js
+++ b/src/backend/fold.js
@@ -37,6 +37,11 @@ function returnTrackColor(trackInfo, id) {
   return trackInfo[id];
 }
 
+function checkNullHtml(html) {
+  html = html.replace(/<\/?[^>]+(>|$)/g, "").trim();
+  return (html === '');
+}
+
 function foldByTrack(sessions, speakers, trackInfo, reqOpts, next) {
   const trackData = new Map();
   const speakersMap = new Map(speakers.map((s) => [s.id, s]));
@@ -98,7 +103,7 @@ function foldByTrack(sessions, speakers, trackInfo, reqOpts, next) {
         spkr.nameIdSlug = slugify(spkr.name + spkr.id);
         return spkr;
       }),
-      description: (session.long_abstract === '') ? session.short_abstract : session.long_abstract,
+      description: (checkNullHtml(session.long_abstract)) ? session.short_abstract : session.long_abstract,
       session_id: session.id,
       sign_up: session.signup_url,
       video: session.video,
@@ -193,7 +198,7 @@ function foldByTime(sessions, speakers, trackInfo) {
         spkr.nameIdSlug = slugify(spkr.name + spkr.id);
         return spkr;
       }),
-      description: (session.long_abstract === '') ? session.short_abstract : session.long_abstract,
+      description: (checkNullHtml(session.long_abstract)) ? session.short_abstract : session.long_abstract,
       session_id: session.id,
       sign_up: session.signup_url,
       video: session.video,
@@ -620,7 +625,7 @@ function foldByRooms(room, sessions, speakers, trackInfo) {
       end : moment.utc(session.end_time).local().format('HH:mm'),
       title: session.title,
       type: (session.session_type == null) ? '' : session.session_type.name,
-      description: (session.long_abstract === '') ? session.short_abstract : session.long_abstract,
+      description: (checkNullHtml(session.long_abstract)) ? session.short_abstract : session.long_abstract,
       session_id: session.id,
       audio:session.audio,
       speakers_list: session.speakers.map((speaker) => {
@@ -722,7 +727,7 @@ function foldBySpeakers(speakers ,sessions, tracksData, reqOpts, next) {
             linkedin: speaker.linkedin ,
             twitter: speaker.twitter ,
             website: speaker.website ,
-            long_biography: (speaker.long_biography === '') ? speaker.short_biography : speaker.long_biography,
+            long_biography: (checkNullHtml(speaker.long_biography)) ? speaker.short_biography : speaker.long_biography,
             mobile: speaker.mobile,
             name: speaker.name,
             thumb: thumb,


### PR DESCRIPTION
Fixes #1185 #1180 
Changes: Adds missing description due to the input <p></p> from api data for long_abstract and short_abstract. Fixes sessions in speakers page for mobile, After clicking the link of session the user is directed to the session data in tracks page.

Demo link:
https://open-event-web-appp.herokuapp.com

Screenshots for the change: 
**Before**
<img width="837" alt="88e870bc-0a91-11e7-9972-296a02f42a28" src="https://cloud.githubusercontent.com/assets/12807846/24079572/074aad3c-0cb1-11e7-9a9d-d0b7164dea9a.png">

**After**
![screen shot 2017-03-19 at 2 27 32 pm](https://cloud.githubusercontent.com/assets/12807846/24079573/0ac332e0-0cb1-11e7-98fa-285b3b47ad9b.png)

@mariobehling @aayusharora @Princu7 Please review. Thanks 
