### PR TITLE
Search in started sessions fixed

### DIFF
--- a/src/backend/templates/rooms.hbs
+++ b/src/backend/templates/rooms.hbs
@@ -261,6 +261,11 @@
     <script type="text/javascript">
       $(document).ready(function() {
 
+        var maxNoOfSessions = 1000;
+        var flag = 0;
+        var isAdded = 0;
+        var mode = 0;
+
         $(function() {
           $("img.lazy").lazyload({
             threshold: 2000
@@ -293,8 +298,10 @@
                     $(this).find('.event').text().toUpperCase().indexOf(filterVal.toUpperCase()) < 0) {
                   $(this).hide();
                 } else {
-                  flag = 0;
-                  $(this).show();
+                  if($(this).is(':visible')) {
+                    flag = 0;
+                    $(this).show();
+                  }
                 }
               });
               if (flag == 1) {
@@ -304,12 +311,16 @@
               }
             });
           } else {
-            $('.date-filter').each(function() {
-              $(this).find('.room-filter').each(function() {
+            if(mode) {
+              display();
+            } else {
+              $('.date-filter').each(function() {
+                $(this).find('.room-filter').each(function() {
+                  $(this).show();
+                });
                 $(this).show();
               });
-              $(this).show();
-            });
+            }
           }
 
           // show "no results" if search input value matches zero items
@@ -323,14 +334,6 @@
         }).keyup(function() {
           $(this).change();
         });
-      });
-    </script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-        var maxNoOfSessions = 1000;
-        var flag = 0;
-        var isAdded = 0;
-        var mode = 0;
 
         $('.bookmark').click(function(){
           flag = 1;

--- a/src/backend/templates/schedule.hbs
+++ b/src/backend/templates/schedule.hbs
@@ -224,6 +224,10 @@
   <script src="./js/schedule.min.js" type="text/javascript"></script>
   <script type="text/javascript">
      $(document).ready(function() {
+       var maxNoOfSessions = 1000;
+       var mode = 0;
+       var flag = 0;
+       var isAdded = 0;
 
        $(function() {
          $("img.lazy").lazyload({
@@ -251,8 +255,10 @@
                               $(this).find('.speaker-name').text().toUpperCase().indexOf(filterVal.toUpperCase()) < 0) {
                                $(this).hide();
                            } else {
-                               flag = 0;
-                               $(this).show();
+                             if($(this).is(':visible')) {
+                                 flag = 0;
+                                 $(this).show();
+                             }
                            }
                       });
                       if (flag == 1) {
@@ -269,15 +275,20 @@
                   }
                 });
               } else {
-                $('.day-filter').each(function() {
-                  $(this).find('.time-filter').each(function() {
-                      $(this).find('.track-inline').each(function() {
-                          $(this).show();
-                      });
-                      $(this).show();
+                var flag = 0;
+                if(mode) {
+                  display();
+                } else {
+                  $('.day-filter').each(function() {
+                    $(this).find('.time-filter').each(function() {
+                        $(this).find('.track-inline').each(function() {
+                            $(this).show();
+                        });
+                        $(this).show();
+                    });
+                    $(this).show();
                   });
-                  $(this).show();
-                });
+                }
               }
 
               // show "no results" if search input value matches zero items
@@ -291,14 +302,6 @@
           }).keyup(function() {
               $(this).change();
           });
-      });
-    </script>
-    <script type="text/javascript">
-        $(document).ready(function() {
-          var maxNoOfSessions = 1000;
-          var mode = 0;
-          var flag = 0;
-          var isAdded = 0;
 
           $('.bookmark').click(function(event){
             var temp = JSON.parse(localStorage['schedule']);

--- a/src/backend/templates/tracks.hbs
+++ b/src/backend/templates/tracks.hbs
@@ -238,6 +238,10 @@
     <script src="./js/bootstrap.min.js" type="text/javascript"></script>
     <script src="./js/tracks.min.js" type="text/javascript"></script>
     <script type="text/javascript">
+      var maxNoOfSessions = 1000;
+      var flag = 0;
+      var isAdded = 0;
+      var mode = 0;
 
       $(function() {
             $("img.lazy").lazyload({
@@ -273,8 +277,10 @@
                     $(this).find('.event').text().toUpperCase().indexOf(filterVal.toUpperCase()) < 0) {
                   $(this).hide();
                 } else {
-                  flag = 0;
-                  $(this).show();
+                  if($(this).is(':visible')) {
+                    flag = 0;
+                    $(this).show();
+                  }
                 }
               });
               if (flag == 1) {
@@ -284,12 +290,16 @@
               }
             });
           } else {
-            $('.date-filter').each(function() {
-              $(this).find('.room-filter').each(function() {
+            if(mode) {
+              display();
+            } else {
+              $('.date-filter').each(function() {
+                $(this).find('.room-filter').each(function() {
+                  $(this).show();
+                });
                 $(this).show();
               });
-              $(this).show();
-            });
+            }
           }
 
           // show "no results" if search input value matches zero items
@@ -303,14 +313,6 @@
         }).keyup(function() {
           $(this).change();
         });
-      });
-    </script>
-    <script type="text/javascript">
-      $(document).ready(function() {
-        var maxNoOfSessions = 1000;
-        var flag = 0;
-        var isAdded = 0;
-        var mode = 0;
 
         $('.bookmark').click(function(){
           flag = 1;


### PR DESCRIPTION
Fixes #1156 

Changes: The search did not work for stared sessions as expected, showing search result from non stared session when in stared mode. The stared search is fixed and is working as expected, when we search in started mode the search shows results only from the stared events. 

Screenshots for the change: 
**All started sessions**
![screen shot 2017-03-19 at 10 45 52 pm](https://cloud.githubusercontent.com/assets/12807846/24083046/e6d55fb2-0cf5-11e7-9741-a9d0510cd53b.png)
**After search**
![screen shot 2017-03-19 at 10 46 15 pm](https://cloud.githubusercontent.com/assets/12807846/24083047/e6d6dffe-0cf5-11e7-966e-7cc3a923091f.png)

Demo server:
http://open-event-web-appp.herokuapp.com

@mariobehling @aayusharora @Princu7 Please review. Thanks