### PR TITLE
Adds missing room name in search results for rooms page

### DIFF
--- a/src/backend/fold.js
+++ b/src/backend/fold.js
@@ -656,19 +656,33 @@ function foldByRooms(room, sessions, speakers, trackInfo) {
   for (let i = 0; i < roomsDetailLength; i++) {
     // sort all sessions in each day by 'venue + date'
     roomsDetail[i].sessions.sort(byProperty('sortKey'));
+    roomsDetail[i].venue = [];
 
     // remove venue names from all but the 1st session in each venue
     let sessionsLength = roomsDetail[i].sessions.length;
     let prevVenue = '';
+    let tempVenue = {};
+    tempVenue.sessions = [];
+
     for (let j = 0; j < sessionsLength; j++) {
       if (roomsDetail[i].sessions[j].venue == prevVenue) {
         roomsDetail[i].sessions[j].venue = '';
+        tempVenue.sessions.push(roomsDetail[i].sessions[j]);
       } else {
+        if(JSON.stringify(tempVenue) != JSON.stringify({}) && prevVenue != '') {
+          roomsDetail[i].venue.push(tempVenue)
+          tempVenue = {};
+          tempVenue.sessions = [];
+        }
+        tempVenue.venue = roomsDetail[i].sessions[j].venue;
+        tempVenue.slug = replaceSpaceWithUnderscore(tempVenue.venue);
+        tempVenue.sessions.push(roomsDetail[i].sessions[j]);
         prevVenue = roomsDetail[i].sessions[j].venue;
       }
     }
+    roomsDetail[i].venue.push(tempVenue);
+    roomsDetail[i].sessions = {};
   }
-
   return roomsDetail;
 }
 

--- a/src/backend/templates/partials/subnavbar.hbs
+++ b/src/backend/templates/partials/subnavbar.hbs
@@ -16,11 +16,11 @@
    <div class="tabs-nav">
       {{#timeList}}
       <a href="#" class="tabs-nav-link">{{date}}</a>
-      {{/timeList}}                          
+      {{/timeList}}
    </div>
    {{#roomsinfo}}
    <div class="tab">
-      <div class="tab-content">{{#sessions}}{{#if venue}}<a href = "./rooms.html#venue-{{session_id}}">{{venue}} {{/if}} </a>{{/sessions}}</div>
+     <div class="tab-content">{{#venue}}{{#sessions}}{{#if venue}}<a href = "./rooms.html#venue-{{../slug}}">{{venue}} {{/if}} </a>{{/sessions}}{{/venue}}</div>
    </div>
    {{/roomsinfo}}
 </div>

--- a/src/backend/templates/rooms.hbs
+++ b/src/backend/templates/rooms.hbs
@@ -87,17 +87,19 @@
                     <h5 class="text">{{date}}</h4>
                   </div>
                 </div>
-                <div class="row">
+                  {{#venue}}
+                  <div class="venue-filter row">
+                    <div class="row">
+                      <div style="clear:both" class="col-md-12">
+                        <a class="anchor" id="venue-{{slug}}"></a>
+                        {{#if venue }}
+                          <h5 class="text">{{venue}}</h5>
+                        {{/if}}
+                      </div>
+                    </div>
                   {{#sessions}}
                       <div class="room-filter" id="{{session_id}}">
                       <a class="anchor" id="venue-{{session_id}}"></a>
-                      <div class="row">
-                        <div style="clear:both" class="col-md-12">
-                        {{#if venue }}
-                        <h5 class="text">{{venue}}</h5>
-                        {{/if}}
-                        </div>
-                      </div>
                       <div class="eventtime col-xs-2 col-sm-2 col-md-2">
                         <span class="time-track">{{start}} - {{end}}</span>
                       </div>
@@ -236,6 +238,7 @@
                   </div>
                   {{/sessions}}
                 </div>
+                {{/venue}}
             </div>
             {{/roomsinfo}}
           </div>
@@ -291,17 +294,26 @@
           if (filterVal) {
             $('.date-filter').each(function() {
               var flag = 1;
-              $(this).find('.room-filter').each(function() {
-                if ($(this).find('.tip-description').text().toUpperCase().indexOf(filterVal.toUpperCase()) < 0 &&
-                    $(this).find('.session-speakers-list a span').text().toUpperCase().indexOf(filterVal.toUpperCase()) < 0 &&
-                    $(this).find('.session-speakers-more').text().toUpperCase().indexOf(filterVal.toUpperCase()) < 0 &&
-                    $(this).find('.event').text().toUpperCase().indexOf(filterVal.toUpperCase()) < 0) {
+              $(this).find('.venue-filter').each(function() {
+                var flagVenue = 1;
+                $(this).find('.room-filter').each(function() {
+                  if ($(this).find('.tip-description').text().toUpperCase().indexOf(filterVal.toUpperCase()) < 0 &&
+                      $(this).find('.session-speakers-list a span').text().toUpperCase().indexOf(filterVal.toUpperCase()) < 0 &&
+                      $(this).find('.session-speakers-more').text().toUpperCase().indexOf(filterVal.toUpperCase()) < 0 &&
+                      $(this).find('.event').text().toUpperCase().indexOf(filterVal.toUpperCase()) < 0) {
+                    $(this).hide();
+                  } else {
+                    if($(this).is(':visible')) {
+                      flag = 0;
+                      flagVenue = 0;
+                      $(this).show();
+                    }
+                  }
+                });
+                if (flagVenue == 1) {
                   $(this).hide();
                 } else {
-                  if($(this).is(':visible')) {
-                    flag = 0;
-                    $(this).show();
-                  }
+                  $(this).show();
                 }
               });
               if (flag == 1) {
@@ -315,7 +327,10 @@
               display();
             } else {
               $('.date-filter').each(function() {
-                $(this).find('.room-filter').each(function() {
+                $(this).find('.venue-filter').each(function() {
+                  $(this).find('.room-filter').each(function() {
+                    $(this).show();
+                  });
                   $(this).show();
                 });
                 $(this).show();
@@ -388,24 +403,31 @@
           var temp = JSON.parse(localStorage['rooms']);
           $('.date-filter').each(function() {
             var dateFlag = 0;
-            $(this).find('.room-filter').each(function() {
-              var elemId = $(this).attr('id');
-              var elemFlag = 0;
-              if(temp[elemId] == 1) {
-                elemFlag = dateFlag = 1;
-                $(this).find('.bookmark').each(function() {
-                  $(this).css("color", "black");
-                });
-              }
-
-              if (elemFlag || !mode) {
+            $(this).find('.venue-filter').each(function() {
+              var venueFlag = 0;
+              $(this).find('.room-filter').each(function() {
+                var elemId = $(this).attr('id');
+                var elemFlag = 0;
+                if(temp[elemId] == 1) {
+                  elemFlag = venueFlag = dateFlag = 1;
+                  $(this).find('.bookmark').each(function() {
+                    $(this).css("color", "black");
+                  });
+                }
+                if (elemFlag || !mode) {
+                  $(this).show();
+                }
+                else {
+                  $(this).hide();
+                }
+              });
+              if(venueFlag || !mode) {
                 $(this).show();
               }
               else {
                 $(this).hide();
               }
             });
-
             if(dateFlag || !mode) {
               $(this).show();
             }


### PR DESCRIPTION
Fixes #1157

Changes: Adds the missing room name for the search results in rooms page. The sessions now lie under the respective room in search result.

Screenshots for the change: 
**BEFORE**
![](https://cloud.githubusercontent.com/assets/12807846/23821619/1f1cc002-065e-11e7-962c-b97e8767c597.png)

**AFTER**
![screen shot 2017-03-21 at 2 17 37 am](https://cloud.githubusercontent.com/assets/12807846/24121105/0a991244-0ddd-11e7-816f-fabe3d40fef4.png)

Demo server : 
https://open-event-web-appp.herokuapp.com/

@mariobehling @aayusharora @Princu7 Please review. Thanks :)