### PR TITLE
Fixed bad session div in case of several speakers

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -675,6 +675,12 @@ a {
   }
 }
 
+.speakers-list {
+  padding: 0;
+  width: auto;
+  max-width:50%;
+}
+
 .track-heading {
   margin-top: 40px;
 }

--- a/src/backend/templates/rooms.hbs
+++ b/src/backend/templates/rooms.hbs
@@ -123,6 +123,8 @@
 			    <div id="desc2-{{session_id}}"
 				class="collapse in"
 				style="background-color:{{{color}}}; margin-top: 0px;">
+        <div class="row">
+        <div class="col-md-6 col-xs-12 speakers-list">
 				{{#speakers_list}}
           <p style="margin-right:20px; float:left" class="session-speakers">
               {{#if photo}}
@@ -132,12 +134,15 @@
               {{/if}}
                       </p>
 		             	{{/speakers_list}}
+                  </div>
+                  <div class="col-md-6">
 		             	<ul style="padding:0;font-size:15px;">
 		             	  {{#speakers_list}}
 		             	    {{name}}{{#if organisation}}&nbsp;({{organisation}}){{/if}}{{#if @last}}{{else}},{{/if}}
 		             	 {{/speakers_list}}
 		             	</ul>
 		             	<ul style="padding:0;font-size:15px;">
+                  </ul>
                     {{#if type}}
                       {{type}}
                     {{else}}

--- a/src/backend/templates/tracks.hbs
+++ b/src/backend/templates/tracks.hbs
@@ -72,7 +72,6 @@
             <input class="fossasia-filter" type="text" placeholder="Search" />
           </span>
         </p>
-
         <div id="session-list" class="container">
           <div class="row">
             <div style="margin: 15px 0 0 15px;" class="col-md-9">
@@ -119,32 +118,33 @@
                             </a>
                           </div>
                           <h4 style="background-color: {{../color}}; margin-top: -15px; padding-top:15px" class="sizeevent event" data-toggle="collapse" data-target="#desc-{{session_id}} .collapse, #desc2-{{session_id}}" aria-expanded="false" aria-controls="desc-{{session_id}}">
-                             {{#if audio}}
+                            {{#if audio}}
                                <i class="fa fa-music" aria-hidden="true" style="margin-left: 10px;"></i>
                             {{/if}}
-			                      <div id="desc2-{{session_id}}" class="collapse in" style="background-color: {{../color}}; margin-top:0px;">
-				                      {{#speakers_list}}
-				                      <p style="margin-right:20px; float:left" class="session-speakers">
-                                {{#if photo}}
-                                    <img onError="this.onerror=null;this.src='./images/avatar.png';" data-original="{{thumb}}" class="lazy card-img-top" style="width:5rem; height:5rem; border-radius:50%;"/>
-                                  {{else}}
-                                    <img class="card-img-top" src="./images/avatar.png" style="width:5rem; height:5rem; border-radius:50%;"/>
-                                {{/if}}
-                              </p>
-		             	            {{/speakers_list}}
-		             	            <ul style="padding:0;font-size:15px;">
-                                        {{#speakers_list}}
-                                            {{name}}{{#if organisation}}&nbsp;({{organisation}}){{/if}}{{#if @last}}{{else}},{{/if}}
-                                        {{/speakers_list}}
-		             	            </ul>
-		             	            <ul style="padding:0;font-size:15px;">
-                                      {{#if type}}
-                                        {{type}}
-                                      {{else}}
-                                          <br>
-                                      {{/if}}
-                              </ul>
-		                        </div>
+			                      <div id="desc2-{{session_id}}" class="collapse in"	style="background-color: {{../color}}; margin-top: 20px;">
+                              <div class="row">
+                                <div class="col-md-6 col-xs-12 speakers-list">
+  				                      {{#speakers_list}}
+                                <p style="margin-right:20px; float:left" class="session-speakers">
+                                  {{#if photo}}
+                                      <img onError="this.onerror=null;this.src='./images/avatar.png';" data-original="{{thumb}}" class="lazy card-img-top" style="width:5rem; height:5rem; border-radius:50%;"/>
+                                    {{else}}
+                                      <img class="card-img-top" src="./images/avatar.png" style="width:5rem; height:5rem; border-radius:50%;"/>
+                                  {{/if}}
+                                </p>
+  		             	            {{/speakers_list}}
+                                </div>
+                                <div class="col-md-6">
+  		             	            <ul style="padding:0;font-size:15px;">
+  		             	              {{#speakers_list}}
+  		             	                {{name}}
+  		             	                {{#if organisation}}({{organisation}}){{/if}}
+  		             	              {{/speakers_list}}
+  		             	            </ul>
+  		             	            <ul style="padding:0;font-size:15px;">{{type}}</ul>
+                                </div>
+		                          </div>
+                            </div>
                           </h4>
                           <div id="desc-{{session_id}}">
                             <div class="collapse">


### PR DESCRIPTION
Fixes #1196.

Changes: Gave 50% of the session div to speaker pictures, and the other half to their description. Live link [here](https://pacific-lowlands-69328.herokuapp.com/).

Screenshots for the change: 
![screenshot from 2017-03-24 23-52-25](https://cloud.githubusercontent.com/assets/3405816/24322606/5f2a87fc-1170-11e7-8e05-67f035a90b66.png)
