### PR TITLE
Removes duplicate navbars for dates in tracks and rooms

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -17,8 +17,12 @@ body {
   visibility: hidden;
 }
 
-.hide {
+.hide-item {
   display: none;
+}
+
+.show-item {
+  display: block;
 }
 
 .h1, .h2, .h3, .h4, .h5, .h6, h1, h2, h3, h4, h5, h6 {
@@ -976,7 +980,7 @@ a {
             height: 300px;
             width: 300px;
 
-            
+
 
             .bio {
               color: $white;
@@ -998,7 +1002,7 @@ a {
         }
 
 
-        &:hover { 
+        &:hover {
             .hover-state {
             opacity: 1;
 
@@ -1435,32 +1439,14 @@ a {
   top: 0;
 }
 
-.tabs {
-  margin-left: -15px;
-}
-
-.tabs-nav {
-  display: flex;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
 .tabs-nav-link {
-  background-color: $gray;
-  color: $white;
-  flex: 1;
-  margin-right: 4px;
-  padding: 12px;
+  background-color: $white;
+  color: $black;
   text-align: center;
   transition: color 0.3s;
 
   &:last-child {
     margin-right: 0;
-  }
-
-  &:hover {
-    color: $border-venue;
   }
 
   &.is-active {
@@ -1666,4 +1652,3 @@ a.skip:hover {
 #speaker-social-icons {
   padding:2%;
 }
-

--- a/src/backend/assets/js/tabs.js
+++ b/src/backend/assets/js/tabs.js
@@ -2,7 +2,7 @@
 var tabs, i, myTabs;
 
 tabs = function(options) {
-  var goToTab, handleClick, init;
+  var goToTab, handleClick, init, handleDisplay;
   var el = document.querySelector(options.el);
   var tabNavigationLinks = el.querySelectorAll(options.tabNavigationLinks);
   var tabContentContainers = el.querySelectorAll(options.tabContentContainers);
@@ -13,10 +13,14 @@ tabs = function(options) {
     if (index !== activeIndex && index >= 0 && index <= tabNavigationLinks.length) {
       if(activeIndex >= 0) {
         tabNavigationLinks[activeIndex].classList.remove('is-active');
-        tabContentContainers[activeIndex].classList.remove('is-active');
+        if(typeof tabContentContainers[index] != 'undefined')
+          tabContentContainers[activeIndex].classList.remove('is-active');
       }
       tabNavigationLinks[index].classList.add('is-active');
-      tabContentContainers[index].classList.add('is-active');
+      if(typeof tabContentContainers[index] != 'undefined')
+        tabContentContainers[index].classList.add('is-active');
+      
+      handleDisplay(tabNavigationLinks[index].className);
       activeIndex = index;
     }
   };
@@ -26,6 +30,19 @@ tabs = function(options) {
       goToTab(index);
     });
   };
+  handleDisplay = function(className) {
+    className = className.split(' ')[0];
+    var dates = document.getElementsByClassName('date-filter');
+    for(i =0; i< dates.length; i++) {
+      if(dates[i].classList.contains(className)) {
+        dates[i].classList.remove('hide-item');
+        dates[i].classList.add('show-item');
+      } else {
+        dates[i].classList.add('hide-item');
+        dates[i].classList.remove('show-item');
+      }
+    }
+  }
   init = function() {
     var link;
 

--- a/src/backend/generator.js
+++ b/src/backend/generator.js
@@ -61,6 +61,15 @@ handlebars.registerHelper('ifvalue', function (conditional, options) {
     }
 });
 
+handlebars.registerHelper('checkpage', function (conditional, options) {
+    if (conditional == options.hash.equals){
+      return options.fn(this);
+    }
+    else{
+      return options.inverse(this);
+    }
+});
+
 function minifyHtml(file) {
   var result = minify(file, {
     removeAttributeQuotes: true,

--- a/src/backend/gulpfile.js
+++ b/src/backend/gulpfile.js
@@ -13,7 +13,7 @@ exports.minifyJs = function (path, cb) {
 
   gulp.task('scheduleJs', function() {
 
-    return gulp.src([dir + 'social.js', dir + 'scroll.js', dir + 'navbar.js', dir + 'jquery.lazyload.js'])
+    return gulp.src([dir + 'social.js', dir + 'scroll.js', dir + 'navbar.js', dir + 'tabs.js', dir + 'jquery.lazyload.js'])
     .pipe(iife({ useStrict : false}))
     .pipe(concat('schedule.min.js'))
     .pipe(babel({ presets: ['es2015'] }))

--- a/src/backend/templates/partials/subnavbar.hbs
+++ b/src/backend/templates/partials/subnavbar.hbs
@@ -1,27 +1,55 @@
 {{#if flag}}
-<div id="tabs" class="tabs no-js">
-   <div class="tabs-nav">
-      {{#days}}
-      <a href="#" class="tabs-nav-link">{{caption}}</a>
-      {{/days}}
-   </div>
-   {{#days}}
-   <div class="tab">
-      <div class="tab-content">{{#tracks}}<a href = "./tracks.html#{{slug}}">{{title}}  </a>{{/tracks}}</div>
-   </div>
-   {{/days}}
-</div>
+  {{#checkpage flag equals='1'}}
+  <span id="tabs" class="tabs no-js">
+     <span class="tabs-nav">
+        {{#days}}
+        <a href="./tracks.html#{{firstSlug}}" class="{{firstSlug}} date-pill tabs-nav-link">{{caption}}</a>
+        {{/days}}
+        <span class="show-button-filter" >
+          <button class = "btn btn-primary" id = "starred" >Show Starred</button>
+        </span>
+        <span class="search-filter">
+            <input class="fossasia-filter" type="text" placeholder="Search" />
+        </span>
+     </span>
+     {{#days}}
+     <span class="tab">
+        <span class="tab-content">{{#tracks}}<a href = "./tracks.html#{{slug}}">{{title}}  </a>{{/tracks}}</span>
+     </span>
+     {{/days}}
+  </span>
+  {{else}}
+  <span id="tabs" class="tabs no-js">
+     <span class="tabs-nav">
+        {{#timeList}}
+        <a href="./schedule.html#{{slug}}" class="{{slug}} date-pill tabs-nav-link">{{date}}</a>
+        {{/timeList}}
+        <span class="show-button-filter" >
+          <button class = "btn btn-primary" id = "starred" >Show Starred</button>
+        </span>
+        <span class="search-filter">
+            <input class="fossasia-filter" type="text" placeholder="Search" />
+        </span>
+     </span>
+  </span>
+{{/checkpage}}
 {{else}}
-<div id="tabs" class="tabs no-js">
-   <div class="tabs-nav">
+<span id="tabs" class="tabs no-js">
+   <span class="tabs-nav">
       {{#timeList}}
-      <a href="#" class="tabs-nav-link">{{date}}</a>
+      <a href="./rooms.html#{{slug}}" class="{{slug}} date-pill tabs-nav-link">{{date}}</a>
       {{/timeList}}
-   </div>
+      <span class="show-button-filter" >
+        <button class = "btn btn-primary" id = "starred" >Show Starred</button>
+      </span>
+      <span class="search-filter">
+          <input class="fossasia-filter" type="text" placeholder="Search" />
+      </span>
+   </span>
    {{#roomsinfo}}
-   <div class="tab">
-     <div class="tab-content">{{#venue}}{{#sessions}}{{#if venue}}<a href = "./rooms.html#venue-{{../slug}}">{{venue}} {{/if}} </a>{{/sessions}}{{/venue}}</div>
-   </div>
+   <span class="tab">
+     <span class="tab-content">{{#venue}}{{#sessions}}{{#if venue}}<a href = "./rooms.html#venue-{{../slug}}">{{venue}} {{/if}} </a>{{/sessions}}{{/venue}}</span>
+   </span>
    {{/roomsinfo}}
-</div>
+</span>
 {{/if}}

--- a/src/backend/templates/rooms.hbs
+++ b/src/backend/templates/rooms.hbs
@@ -64,23 +64,14 @@
         text across the page.
         --------------------------------------------------------------- -->
     <p class="date-list">
-        {{#timeList}}
-          <span class="date-pill"><a href="./rooms.html#{{slug}}"> {{date}} </a></span>
-        {{/timeList}}
-        <span class="show-button-filter" >
-          <button class = "btn btn-primary" id = "starred" >Show Starred</button>
-        </span>
-        <span class="search-filter">
-            <input class="fossasia-filter" type="text" placeholder="Search" />
-        </span>
+        {{> subnavbar flag = 0}}
     </p>
     <div id="session-list" class="container">
       <div class="row">
         <div id="content-block" class="col-md-9">
-                      {{> subnavbar flag = 0}}
           <div id="track-list">
             {{#roomsinfo}}
-            <div class="date-filter" id="rooms-list">
+            <div class="date-filter {{slug}}" id="rooms-list">
                 <div class="row paddingzero">
                   <div class="col-md-12 paddingzero">
                     <a class="anchor" id="{{slug}}"></a>

--- a/src/backend/templates/schedule.hbs
+++ b/src/backend/templates/schedule.hbs
@@ -62,15 +62,7 @@
         text across the page.
         --------------------------------------------------------------- -->
     <p class="date-list">
-    {{#timeList}}
-      <span class="date-pill"><a href="./schedule.html#{{slug}}"> {{date}} </a></span>
-    {{/timeList}}
-    <span class = "show-button-filter">
-      <button class = "btn btn-primary" id = "starred" >Show Starred</button>
-    </span>
-    <span class="search-filter">
-        <input class="fossasia-filter" type="text" placeholder="Search" />
-    </span>
+    {{> subnavbar flag = 2}}
     </p>
 
     <div class="row">
@@ -78,7 +70,7 @@
         <div id="track-list" class="container">
 
           {{#timeList}}
-          <div class="day-filter">
+          <div class="day-filter date-filter {{slug}}">
             <div class="col-md-12 paddingzero">
               <a class="anchor" id="{{slug}}"></a>
               <h4 class="text">{{date}}</h4>

--- a/src/backend/templates/tracks.hbs
+++ b/src/backend/templates/tracks.hbs
@@ -62,23 +62,14 @@
       text across the page.
       --------------------------------------------------------------- -->
   <p class="date-list">
-    {{#days}}
-      <span class="date-pill"><a href="./tracks.html#{{firstSlug}}"> {{caption}} </a></span>
-    {{/days}}
-    <span class="show-button-filter">
-            <button class="btn btn-primary" id="starred">Show Starred</button>
-          </span>
-    <span class="search-filter">
-            <input class="fossasia-filter" type="text" placeholder="Search"/>
-          </span>
+    {{> subnavbar flag = 1}}
   </p>
   <div id="session-list" class="container">
     <div class="row">
       <div id="content-block" class="col-md-9">
-        {{> subnavbar flag = 1}}
         <div id="track-list">
           {{#days}}
-            <div class="date-filter">
+            <div class="date-filter {{firstSlug}}">
               <div class="row paddingzero">
                 <div class="col-md-12 paddingzero">
                   <a class="anchor" id="{{firstSlug}}"></a>


### PR DESCRIPTION
Fixes #1206 

Changes: Removes the duplicate navbars for dates in tracks and rooms page. Introduces a single unified navbar for dates and jump links in tracks and rooms page.
Screenshots for the change: 
**Before**
![screen shot 2017-04-17 at 11 10 41 pm](https://cloud.githubusercontent.com/assets/12807846/25097706/392e5f14-23c3-11e7-9cce-80236edced33.png)
![screen shot 2017-04-17 at 11 11 22 pm](https://cloud.githubusercontent.com/assets/12807846/25097709/3959bd9e-23c3-11e7-8c43-c90fa30c0991.png)

**After**
![screen shot 2017-04-17 at 11 10 53 pm](https://cloud.githubusercontent.com/assets/12807846/25097707/393e23cc-23c3-11e7-924a-bed3fb72301d.png)
![screen shot 2017-04-17 at 11 11 13 pm](https://cloud.githubusercontent.com/assets/12807846/25097708/394a8518-23c3-11e7-9c95-d67e8fd3805a.png)

Demo server : https://open-event-web-appp.herokuapp.com
@mariobehling @aayusharora @Princu7 Please review. Thanks.