### PR TITLE
Hides calendar view onload, introduced in PR #1226

### DIFF
--- a/src/backend/templates/schedule.hbs
+++ b/src/backend/templates/schedule.hbs
@@ -385,6 +385,7 @@
          $("img.lazy").lazyload({
            threshold: 2000
          });
+         $('.calendar-view').hide();
        });
 
       $('.session-lin').click(function() {


### PR DESCRIPTION
The calendar view gets appended to the list view when the page is load for the first time. It was introduced in #1226 which intends to solve #1215.

Screenshot:
**BEFORE**
![screen shot 2017-04-24 at 6 08 15 pm](https://cloud.githubusercontent.com/assets/12807846/25337379/48c541b2-2919-11e7-8002-e13b2a75e3ba.png)

**AFTER**
![screen shot 2017-04-24 at 6 15 07 pm](https://cloud.githubusercontent.com/assets/12807846/25337560/fb4ef648-2919-11e7-86d5-18c1606fd6ba.png)

Demo server:
https://open-event-web-appp.herokuapp.com/
@aayusharora Please merge this. Sorry for the problem caused. Thanks