### PR TITLE
Fixes rooms navbar

### DIFF
--- a/src/backend/templates/partials/subnavbar.hbs
+++ b/src/backend/templates/partials/subnavbar.hbs
@@ -20,7 +20,7 @@
    </div>
    {{#roomsinfo}}
    <div class="tab">
-     <div class="tab-content">{{#venue}}{{#sessions}}{{#if venue}}<a href = "./rooms.html#venue-{{../slug}}">{{venue}} {{/if}} </a>{{/sessions}}{{/venue}}</div>
+     <div class="tab-content">{{#venue}}{{#if venue}}<a href = "./rooms.html#venue-{{../slug}}-{{slug}}">{{venue}} {{/if}} </a>{{/venue}}</div>
    </div>
    {{/roomsinfo}}
 </div>

--- a/src/backend/templates/rooms.hbs
+++ b/src/backend/templates/rooms.hbs
@@ -91,7 +91,7 @@
                   <div class="venue-filter row">
                     <div class="row">
                       <div style="clear:both" class="col-md-12">
-                        <a class="anchor" id="venue-{{slug}}"></a>
+                        <a class="anchor" id="venue-{{../slug}}-{{slug}}"></a>
                         {{#if venue }}
                           <h5 class="text">{{venue}}</h5>
                         {{/if}}


### PR DESCRIPTION
Fixes #1241 

Changes: The navbar in rooms table scrolls to the correct room for all the dates. Which previously was pointing to same position in the HTML.

Please check #1241 for details about the issue

Demo server : https://open-event-web-appp.herokuapp.com/
@mariobehling @aayusharora Please merge this. Thanks