### PR TITLE
Optimises calendar width for any number of room columns

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -1597,6 +1597,12 @@ a.skip:hover {
   display: block;
 }
 
+.calendar-footer {
+  position: absolute;
+  background-color: $white;
+  width: 100%;
+}
+
 .times {
   width: 48px;
   float: left;
@@ -1604,6 +1610,7 @@ a.skip:hover {
 }
 
 .rooms {
+  overflow: hidden;
   overflow-x : auto;
   width: calc(100% - 80px);
   display: inline-block;
@@ -1639,6 +1646,7 @@ a.skip:hover {
   position: absolute;
   border: 1px solid $gray-extra-dark;
   width: 100%;
+  word-wrap: break-word;
 }
 
 .session-name {

--- a/src/backend/assets/js/popover.js
+++ b/src/backend/assets/js/popover.js
@@ -78,9 +78,13 @@ $(document).ready(function () {
 
   function resetPage() {
     if(previousRoomHeight > 0) {
+      let footer = $(roomsdiv).find('.calendar-footer');
       $(roomsdiv).css({
         "height": previousRoomHeight
-      })
+      });
+      $(footer).css({
+        "height": 0
+      });
     }
   }
 
@@ -88,6 +92,7 @@ $(document).ready(function () {
 
     if(session.is(element)) {
       let rooms = $(element).parent().parent().parent();
+      let footer = $(rooms).find('.calendar-footer');
       let roomsPosition = $(rooms).offset();
       let roomsHeight = $(rooms).outerHeight();
       let roomsWidth = $(rooms).outerWidth();
@@ -102,14 +107,14 @@ $(document).ready(function () {
       roomsdiv = $(rooms).hasClass('rooms') ? rooms : roomsdiv;
 
       if(openedPop !== null) {
-        //console.log(popTop + popHeight);
         let parentWidth = roomsPosition.left + roomsWidth;
         let childWidth = popPosition.left + popWidth;
         let parentHeight = roomsPosition.top + roomsHeight;
         let childHeight = popPosition.top + popHeight;
 
         let diff = 0,
-            popDiff = 0;
+            popDiff = 0,
+            footerOffset = 0;
 
         //Change the left value of popbox and avoid increase in width
         if(childWidth >= parentWidth) {
@@ -121,11 +126,16 @@ $(document).ready(function () {
         }
 
         if(childHeight >= parentHeight) {
-          diff = childHeight - parentHeight;
-          diff = roomsHeight + diff + 20;
+          diff = childHeight - parentHeight + 30;
+          footerOffset = diff + 50;
+          diff = roomsHeight + diff;
           previousRoomHeight = previousRoomHeight === 0 ? roomsHeight : previousRoomHeight;
           $(rooms).css({
             "height": diff
+          });
+          $(footer).css({
+            "top": previousRoomHeight,
+            "height": footerOffset
           });
         }
       } else {

--- a/src/backend/fold.js
+++ b/src/backend/fold.js
@@ -70,7 +70,7 @@ function createTimeLine(startTime, endTime) {
   let endHour = parseInt(getHoursFromTime(endTime));
   let i = 0;
   let time = '';
-  let height = timeToPixel / 2;
+  let height = timeToPixel;
 
   while(startHour <= endHour) {
     time = startHour < 10 ? '0' + startHour : startHour;

--- a/src/backend/templates/schedule.hbs
+++ b/src/backend/templates/schedule.hbs
@@ -349,6 +349,7 @@
                     </div>
                   </div>
                   {{/venue}}
+                  <div class="calendar-footer"></div>
                 </div>
               </div>
             </div>
@@ -528,6 +529,8 @@
           function adjustCalendar(element) {
             let rooms = $(element).find('.calendar-content').find('.rooms');
             let width = 0;
+            let offset = 0;
+            let roomCount = 0;
 
             $(rooms).find('.room').each(function() {
               width += $(this).outerWidth();
@@ -539,9 +542,18 @@
                     $(sessionName).html(textArray.join(' ') + '...');
                 }
               })
+              roomCount++;
             });
+
             if(width < $(rooms).width()) {
-              $(rooms).width(width);
+              offset = ($(rooms).width() - width)/roomCount;
+              $(rooms).find('.room').each(function() {
+                let currentWidth = $(this).width() + offset;
+                $(this).css({
+                  'width': currentWidth,
+                  'max-width': currentWidth
+                });
+              });
             }
           }
 


### PR DESCRIPTION
Fixes #1233 

Changes: Makes the width of the calendar adaptable. The calendar takes up 100% width of its container irrespective of the number of columns.

Screenshots for the change: 
**BEFORE**
![screen shot 2017-04-27 at 7 38 05 pm](https://cloud.githubusercontent.com/assets/12807846/25518060/d847355e-2c0f-11e7-82bc-cd2e943bd954.png)


**AFTER**
![screen shot 2017-04-28 at 12 40 07 pm](https://cloud.githubusercontent.com/assets/12807846/25518061/d8606d08-2c0f-11e7-8fc9-78f62a5ddf2b.png)


Demo server : https://open-event-web-appp.herokuapp.com
Gh-pages : https://geekyd.github.io/eventApplication

@mariobehling @aayusharora @Princu7 Please review. Thanks