### PR TITLE
Fixes #1255

### DIFF
--- a/src/backend/fold.js
+++ b/src/backend/fold.js
@@ -104,8 +104,8 @@ function checkWidth(columns) {
 
 function convertLicenseToCopyright(licence, copyright) {
   var data = {};
-  data.licence_url = licence.licence_url;
-  data.logo = licence.logo;
+  data.licence_url = licence.licence_url === undefined ? licence.url : licence.licence_url;
+  data.logo = licence.compact_logo === undefined ? licence.logo : licence.compact_logo;
   data.licence = licence.long_name;
   data.year = copyright.year;
   data.holder = copyright.holder;

--- a/src/backend/templates/partials/footer.hbs
+++ b/src/backend/templates/partials/footer.hbs
@@ -28,11 +28,16 @@
          {{#if copyright}}
          {{#if copyright.licence}}
          <p>
-         <a href="{{{copyright.licence_url}}}"> <img src="{{{copyright.logo}}}"> </a>
-         &copy; {{copyright.year}}
+        <a href="{{{copyright.licence_url}}}"><img src="{{{copyright.logo}}}"></a>
+         &nbsp; &copy; {{copyright.year}}
+         {{#if copyright.holder_url}}
          <a href="{{{copyright.holder_url}}}">{{copyright.holder}}.</a>
+         {{else}}
+         {{copyright.holder}}.
+         {{/if}}
          The website and it's contents are licensed under
           <a href="{{{copyright.licence_url}}}"> {{copyright.licence}}. </a>
+         The site was generated using the Open Event format on the <a href="https://eventyay.com/">eventyay</a> <a href="https://webgen.eventyay.com/">site generator</a>. Please submit issues <a href="https://github.com/fossasia/open-event-webapp/issues">here</a>.
          </p>
          {{/if}}
         {{/if}}


### PR DESCRIPTION
First steps for  [#1255]

Changes: 
- [x]  Please use the small Creative Commons buttons instead of large buttons.
- [x]  Store buttons on the itself. Do not embed external buttons.
- [x] Use the correct link to the actual license.
- [x] There is a link to the organizer, e.g. "© 2017 FOSSASIA and Science Centre Singapore." with a wrong link. Take out that link.
- [x] Behind "The website and it's contents are licensed under Creative Commons Attribution 4.0 International License." or similar add the following: "The site was generated using the Open Event format on the eventyay site generator. Please submit issues here."

1-Changed the larger Creative Common button to smaller one.
2-Due to mismatch of JSON keys, some license links were rendered null. That is fixed now.
3-If `holder_url` is not provided in data then `holder name` on the site won't be a link.


Before Changes
[https://demolp.github.io/OSCAL%202017/](https://demolp.github.io/OSCAL%202017/)

After Changes
[https://demolp.github.io/OSCAL2017new/](https://demolp.github.io/OSCAL2017new/)

