### PR TITLE
Removes the duplicacy of speaker photo on expansion in rooms page

### DIFF
--- a/src/backend/templates/rooms.hbs
+++ b/src/backend/templates/rooms.hbs
@@ -121,8 +121,8 @@
                             {{#if audio}}
                                <i class="fa fa-music" aria-hidden="true"></i>
                             {{/if}}
-			   <div id="desc2-{{session_id}} margin-top-zero"
-				class="collapse in"
+			   <div id="desc2-{{session_id}}"
+				class="collapse in margin-top-zero"
 				style="background-color:{{{color}}};">
         <div class="row">
         <div class="col-md-6 col-xs-12 speakers-list">


### PR DESCRIPTION
**Fixes**  #1276 

**Changes**:  Removes the duplicity of speaker photo on expansion in rooms page

**Screenshots for the change**: 

* Before
![screenshot from 2017-05-15 21-11-33](https://cloud.githubusercontent.com/assets/8847265/26066555/f08fb98a-39b4-11e7-870d-21c9617a214d.png)

* After
![screenshot from 2017-05-15 21-21-56](https://cloud.githubusercontent.com/assets/8847265/26066576/f9c986fc-39b4-11e7-9277-e3a5c8b11c8b.png)

**Deployment Link**: http://princu7.github.io/open-event-webapp
@mariobehling  @aayusharora @geekyd  Please Review




