### PR TITLE
Set the font color of the tracks in accordance with the latest API spec

### DIFF
--- a/src/backend/fold.js
+++ b/src/backend/fold.js
@@ -40,6 +40,13 @@ function returnTrackColor(trackInfo, id) {
   return trackInfo[id];
 }
 
+function returnTrackFontColor(trackInfo, id) {
+  if ((trackInfo === null) || (id === null)) {
+    return '#000000';
+  }
+  return trackInfo[id];
+}
+
 function checkNullHtml(html) {
   html = html.replace(/<\/?[^>]+(>|$)/g, "").trim();
   return (html === '');
@@ -117,9 +124,11 @@ function foldByTrack(sessions, speakers, trackInfo, reqOpts, next) {
   const trackData = new Map();
   const speakersMap = new Map(speakers.map((s) => [s.id, s]));
   const trackDetails = new Object();
+  const trackDetailsFont = new Object();
 
   trackInfo.forEach((track) => {
     trackDetails[track.id] = track.color;
+    trackDetailsFont[track.id] = (track.font_color !== null) ? track.font_color : '#000000';
   });
 
   async.eachSeries(sessions,(session,callback) => {
@@ -140,7 +149,8 @@ function foldByTrack(sessions, speakers, trackInfo, reqOpts, next) {
     if (!trackData.has(slug) && (session.track != null)) {
       track = {
         title: session.track.name,
-        color: returnTrackColor(trackDetails, (session.track == null) ? null : session.track.id),
+        color: returnTrackColor(trackDetails, (session.track === null) ? null : session.track.id),
+        font_color: returnTrackFontColor(trackDetailsFont, (session.track === null) ? null : session.track.id),
         date: moment.utc(session.start_time).local().format('dddd, Do MMM'),
         sortKey: moment.utc(session.start_time).local().format('YY-MM-DD'),
         slug: slug,
@@ -224,9 +234,11 @@ function foldByTime(sessions, speakers, trackInfo) {
   let dateMap = new Map();
   const speakersMap = new Map(speakers.map((s) => [s.id, s]));
   const trackDetails = {};
+  const trackDetailsFont = {};
 
   trackInfo.forEach((track) => {
     trackDetails[track.id] = track.color;
+    trackDetailsFont[track.id] = (track.font_color !== null) ? track.font_color : '#000000';
   });
 
   sessions.forEach((session) => {
@@ -261,6 +273,7 @@ function foldByTime(sessions, speakers, trackInfo) {
       start: moment.utc(session.start_time).local().format('HH:mm'),
       end : moment.utc(session.end_time).local().format('HH:mm'),
       color: returnTrackColor(trackDetails, (session.track == null) ? null : session.track.id),
+      font_color: returnTrackFontColor(trackDetailsFont, (session.track == null) ? null : session.track.id),
       title: session.title,
       type: session_type,
       location: roomName,
@@ -317,9 +330,11 @@ function returnTracknames(sessions, trackInfo) {
 
   const trackData = new Map();
   const trackDetails = new Object();
+  const trackDetailsFont = new Object();
 
   trackInfo.forEach((track) => {
     trackDetails[track.id] = track.color;
+    trackDetailsFont[track.id] = (track.font_color !== null) ? track.font_color : '#000000';
   });
 
   sessions.forEach((session) => {
@@ -337,6 +352,7 @@ function returnTracknames(sessions, trackInfo) {
       track = {
         title: session.track.name,
         color: returnTrackColor(trackDetails, (session.track == null) ? null : session.track.id),
+        font_color: returnTrackFontColor(trackDetailsFont, (session.track === null) ? null : session.track.id),
         sortKey: moment.utc(session.start_time).local().format('YY-MM-DD'),
         slug: slug
       };
@@ -615,8 +631,11 @@ function sessionsByRooms(id, sessions, trackInfo) {
   var sessionInRooms = [];
   const DateData = new Map();
   const trackDetails = new Object();
+  const trackDetailsFont = new Object();
+
    trackInfo.forEach((track) => {
     trackDetails[track.id] = track.color;
+    trackDetailsFont[track.id] = (track.font_color !== null) ? track.font_color : '#000000';
   });
 
   sessions.forEach((session) => {
@@ -636,7 +655,8 @@ function sessionsByRooms(id, sessions, trackInfo) {
           date: dated ,
           name: session.title,
           time: moment.utc(session.start_time).local().format('HH:mm'),
-          color: returnTrackColor(trackDetails, (session.track == null) ? null : session.track.id)
+          color: returnTrackColor(trackDetails, (session.track === null) ? null : session.track.id),
+          font_color: returnTrackFontColor(trackDetailsFont, (session.track === null) ? null : session.track.id)
         });
         DateData.set(slug,moment.utc(session.start_time).local().format('YYYY-MM-DD'));
       }
@@ -650,11 +670,14 @@ function sessionsByRooms(id, sessions, trackInfo) {
 
 function foldByRooms(room, sessions, speakers, trackInfo) {
   const roomData = new Map();
-  const trackDetails = new Object();
+  const trackDetails = {};
+  const trackDetailsFont = {};
   const speakersMap = new Map(speakers.map((s) => [s.id, s]));
   const microlocationArray = [];
+
   trackInfo.forEach((track) => {
     trackDetails[track.id] = track.color;
+    trackDetailsFont[track.id] = (track.font_color !== null) ? track.font_color : '#000000';
   });
 
   sessions.forEach((session) => {
@@ -711,7 +734,8 @@ function foldByRooms(room, sessions, speakers, trackInfo) {
 
     room.sessions.push({
       start: start,
-      color: returnTrackColor(trackDetails, (session.track == null) ? null : session.track.id),
+      color: returnTrackColor(trackDetails, (session.track === null) ? null : session.track.id),
+      font_color: returnTrackFontColor(trackDetailsFont, (session.track === null) ? null : session.track.id),
       venue: venue,
       end : end,
       title: session.title,
@@ -864,10 +888,12 @@ function foldBySpeakers(speakers ,sessions, tracksData, reqOpts, next) {
 function getAllSessions(speakerid , session, trackInfo){
   let speakersession =[];
   let sessiondetail = [];
-  let trackDetails = new Object();
+  let trackDetails = {};
+  let trackDetailsFont = {};
 
   trackInfo.forEach((track) => {
     trackDetails[track.id] = track.color;
+    trackDetailsFont[track.id] = (track.font_color !== null) ? track.font_color : '#000000';
   });
 
   const sessionsMap = new Map(session.map((s) => [s.id, s]));
@@ -893,7 +919,8 @@ function getAllSessions(speakerid , session, trackInfo){
         end:   moment.utc(session.detail.end_time).local().format('HH:mm'),
         title: session.detail.title,
         date: moment.utc(session.detail.start_time).local().format('ddd, Do MMM'),
-        color: returnTrackColor(trackDetails, (session.detail.track == null) ? null : session.detail.track.id),
+        color: returnTrackColor(trackDetails, (session.detail.track === null) ? null : session.detail.track.id),
+        font_color: returnTrackFontColor(trackDetailsFont, (session.detail.track === null) ? null : session.detail.track.id),
         microlocation: roomname,
         session_id: session.detail.id
       });

--- a/src/backend/templates/rooms.hbs
+++ b/src/backend/templates/rooms.hbs
@@ -107,14 +107,16 @@
                       </div>
                       <div class="room-container">
                         <div class="left-border col-xs-10 col-sm-10 col-md-10">
-                          <div class = "sizeevent event" id="event-title" style = "background-color: {{{color}}};">
+                            <div class = "sizeevent event" id="event-title" style = "background-color: {{{color}}};
+                              color: {{{font_color}}};">
                           {{title}}
                           <a class = "bookmark" >
                             <i class="fa fa-star" aria-hidden="true" >
                             </i>
                           </a>
                           </div>
-                          <h4 id="event-upper-block" style="background-color:{{{color}}};"  class="sizeevent event" data-toggle="collapse"
+                          <h4 id="event-upper-block" style="background-color:{{{color}}}; color: {{{font_color}}};"
+                            class="sizeevent event" data-toggle="collapse"
                             data-target="#desc-{{session_id}} .collapse, #desc2-{{session_id}}"
                             aria-expanded="false"
                             aria-controls="desc-{{session_id}}">
@@ -123,7 +125,7 @@
                             {{/if}}
 			   <div id="desc2-{{session_id}}"
 				class="collapse in margin-top-zero"
-				style="background-color:{{{color}}};">
+                style="background-color:{{{color}}}; color: {{{font_color}}};">
         <div class="row">
         <div class="col-md-6 col-xs-12 speakers-list">
 				{{#speakers_list}}
@@ -231,7 +233,7 @@
                                 {{/if}}
                                 <p>
                                   <ul class="title-inline">
-                                    <li  style="background-color:{{{color}}}" class="titlecolor"></li>&nbsp;
+                                    <li style="background-color:{{{color}}}; color: {{{font_color}}};" class="titlecolor"></li>&nbsp;
                                     <li class="blacktext">{{tracktitle}}</li>
                                   </ul>
                                 </p><br>
@@ -252,7 +254,7 @@
         {{#tracknames}}
         {{#if title}}
           <ul class="title-inline title-legend">
-            <li  style="background-color:{{{color}}}" class="titlecolor"></li>
+            <li style="background-color:{{{color}}}; color: {{{font_color}}};" class="titlecolor"></li>
             <li>{{title}}</li>
           </ul>
         {{/if}}

--- a/src/backend/templates/schedule.hbs
+++ b/src/backend/templates/schedule.hbs
@@ -111,10 +111,11 @@
                   <a class="anchor" id="s-{{session_id}}"></a>
                   <div class="schedule-container">
                     <div class="padding-right-zero">
-                      <h4 style="background-color:{{{color}}};"  class="margin-right-zero sizeevent event"  data-toggle="collapse"
-                        data-target="#desc-{{session_id}} .collapse"
-                        aria-expanded="false"
-                        aria-controls="desc-{{session_id}}">
+                        <h4 style="background-color:{{{color}}}; color: {{{font_color}}};"
+                          class="margin-right-zero sizeevent event"  data-toggle="collapse"
+                          data-target="#desc-{{session_id}} .collapse"
+                          aria-expanded="false"
+                          aria-controls="desc-{{session_id}}">
                         {{title}}
                         {{#if audio}}
                           <i class="fa fa-music" aria-hidden="true"></i>
@@ -200,7 +201,7 @@
                             <p>{{sessiondate}}, <span>{{start}} - {{end}}</span></p>
                             <p>
                               <ul class="title-inline">
-                                <li style="background-color:{{{color}}}" class="titlecolor"></li>&nbsp;
+                                <li style="background-color:{{{color}}}; color: {{{font_color}}};" class="titlecolor"></li>&nbsp;
                                 <li class="blacktext">{{tracktitle}}</li>
                               </ul>
                             </p><br>
@@ -252,7 +253,8 @@
                     </div>
                     <div class="session-container">
                       {{#sessions}}
-                      <div class="session" style="top:{{{top}}}px; height:{{{height}}}px;background-color:{{{color}}}">
+                        <div class="session" style="top:{{{top}}}px; height:{{{height}}}px;background-color:{{{color}}};
+                          color: {{{font_color}}};">
                         <div class="session-name">{{title}}</div>
                         <div class="pop-box hide">
                           <div class="arrow">
@@ -341,7 +343,8 @@
                                      {{/if}}
                                      <p>
                                        <ul class="title-inline">
-                                         <li style="background-color:{{{color}}}" class="titlecolor"></li>&nbsp;
+                                         <li style="background-color:{{{color}}}; color: {{{font_color}}};"
+                                           class="titlecolor"></li>&nbsp;
                                          <li class="blacktext">{{tracktitle}}</li>
                                        </ul>
                                      </p><br>
@@ -368,7 +371,7 @@
       {{#tracknames}}
       {{#if title}}
         <ul class="title-inline title-legend">
-          <li style="background-color:{{{color}}}" class="titlecolor"></li>
+          <li style="background-color:{{{color}}}; color: {{{font_color}}};" class="titlecolor"></li>
           <li>{{title}}</li>
         </ul>
       {{/if}}

--- a/src/backend/templates/tracks.hbs
+++ b/src/backend/templates/tracks.hbs
@@ -113,21 +113,22 @@
                       </div>
                       <div class="room-container">
                         <div class="left-border col-xs-10 col-sm-10 col-md-10">
-                          <div class="sizeevent event" id="event-title" style="background-color: {{../color}};">
+                            <div class="sizeevent event" id="event-title" style="background-color: {{../color}}; color:{{../font_color}};">
                             {{title}}
                             <a class="bookmark">
                               <i class="fa fa-star" aria-hidden="true">
                               </i>
                             </a>
                           </div>
-                          <h4 id="event-upper-block" style="background-color: {{../color}};" class="sizeevent event"
-                              data-toggle="collapse" data-target="#desc-{{session_id}} .collapse, #desc2-{{session_id}}"
-                              aria-expanded="false" aria-controls="desc-{{session_id}}">
+                          <h4 id="event-upper-block" style="background-color: {{../color}}; color:{{../font_color}};"
+                            class="sizeevent event"
+                            data-toggle="collapse" data-target="#desc-{{session_id}} .collapse, #desc2-{{session_id}}"
+                            aria-expanded="false" aria-controls="desc-{{session_id}}">
                             {{#if audio}}
                               <i class="fa fa-music" aria-hidden="true"></i>
                             {{/if}}
                             <div id="desc2-{{session_id}}" class="margin-top-zero collapse in"
-                                 style="background-color: {{../color}};">
+                                style="background-color: {{../color}}; color: {{../font_color}};">
                               <div class="row">
                                 <div class="col-md-6 col-xs-12 speakers-list">
                                   {{#speakers_list}}
@@ -224,7 +225,8 @@
                                 {{#if ../date}}<p>{{../date}}, <span>{{start}} - {{end}}</span></p>{{/if}}
                                 <p>
                                 <ul class="title-inline">
-                                  <li style="background-color:{{{../color}}}" class="titlecolor"></li>
+                                  <li style="background-color:{{{../color}}};color:{{{../font_color}}};"
+                                    class="titlecolor"></li>
                                   &nbsp;
                                   <li class="blacktext">{{../title}}</li>
                                 </ul>
@@ -246,7 +248,7 @@
         {{#tracknames}}
           {{#if title}}
             <ul class="title-inline title-legend">
-              <li style="background-color: {{color}}" class="titlecolor"></li>
+              <li style="background-color: {{color}}; color:{{../font_color}};" class="titlecolor"></li>
               <li>{{title}}</li>
             </ul>
           {{/if}}


### PR DESCRIPTION
Fixes #1281 

**Changes**: The font color of the tracks on different pages(schedule, rooms, and tracks) are set in accordance with the latest API specification of the server. This will result in better UI and the font color will be more readable to the eyes and looks good on the background color.

**Screenshots for the change**: 

* Schedule Page
![screenshot from 2017-05-17 17-41-15](https://cloud.githubusercontent.com/assets/8847265/26153430/e2913b68-3b28-11e7-88ca-7ecf9de5c93d.png)

* Tracks Page
![screenshot from 2017-05-17 17-41-29](https://cloud.githubusercontent.com/assets/8847265/26153493/2e26b620-3b29-11e7-8c91-385723027393.png)

**Live Link**: http://princu7.github.io/eventSiteWebApp





