### PR TITLE
Correct the behaviour of collapsible session elements on rooms page in

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -1697,6 +1697,10 @@ a.skip:hover {
   position: relative;
 }
 
+.room-filter {
+  overflow: hidden;
+}
+
 .room-header {
   padding-left: 2px;
   padding-right: 2px;


### PR DESCRIPTION
Firefox browser.

Fixes #1280 

**Changes**: The session elements on the rooms page were not expanding and collapsible correctly. This was weird since the bug seems to only present on the Firefox browser and everything worked nicely on the Chrome. On further investigation, I found that the height of the session element was zero(because of floating elements inside it and hence it was collapsed). Due to this, Firefox was not able to correctly expand and collapse the element. Upon adding the property to make the height of the session element non-zero and computable, things started to work again.

**Screenshots for the change**: 
* Before
![screenshot from 2017-05-19 17-34-39](https://cloud.githubusercontent.com/assets/8847265/26247101/fa3c7650-3cb9-11e7-864c-8d97ab17ae10.png)
![screenshot from 2017-05-19 17-34-45](https://cloud.githubusercontent.com/assets/8847265/26247120/0d41cff2-3cba-11e7-84d7-2f2a91fc5b6a.png)

* After
![screenshot from 2017-05-19 17-34-52](https://cloud.githubusercontent.com/assets/8847265/26247122/0d465554-3cba-11e7-8cab-9c90ec21c70e.png)
![screenshot from 2017-05-19 17-34-56](https://cloud.githubusercontent.com/assets/8847265/26247121/0d4348b4-3cba-11e7-8768-e98453c84c52.png)

**Deployment Link**:  http://princu7.github.io/open-event-webapp




