### PR TITLE
Added sauce labs connection in Travis for running selenium tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 env:
   - CXX=g++-4.8
 addons:
+  sauce_connect: true
   apt:
     sources:
       - ubuntu-toolchain-r-test


### PR DESCRIPTION
Related to the issue #1291 

Adds `sauce` labs connection to `Travis CI` for running `selenium` tests. Travis doesn't support selenium natively hence we have to run the tests on Sauce Clouds by making a remote connection to it. There are a bunch of steps to be followed for it. I read the official guide for it here:
https://docs.travis-ci.com/user/gui-and-headless-browsers/

Already added the environment variables mentioned in the guide to Travis. Will be adding the actual tests in the upcoming days. Thanks!!