### PR TITLE
Add a very basic Selenium test to check the name of the event

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -17,6 +17,11 @@
       "from": "addressparser@1.0.1",
       "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-1.0.1.tgz"
     },
+    "adm-zip": {
+      "version": "0.4.7",
+      "from": "adm-zip@>=0.4.7 <0.5.0",
+      "resolved": "http://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz"
+    },
     "after": {
       "version": "0.8.2",
       "from": "after@0.8.2",
@@ -3190,6 +3195,11 @@
         }
       }
     },
+    "selenium-webdriver": {
+      "version": "3.4.0",
+      "from": "selenium-webdriver@latest",
+      "resolved": "http://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-3.4.0.tgz"
+    },
     "semver": {
       "version": "5.0.3",
       "from": "semver@>=5.0.1 <5.1.0",
@@ -3520,6 +3530,11 @@
       "version": "1.1.0",
       "from": "time-stamp@>=1.0.0 <2.0.0",
       "resolved": "http://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz"
+    },
+    "tmp": {
+      "version": "0.0.30",
+      "from": "tmp@0.0.30",
+      "resolved": "http://registry.npmjs.org/tmp/-/tmp-0.0.30.tgz"
     },
     "to-array": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "progress-stream": "^1.2.0",
     "recursive-readdir": "^2.1.0",
     "request": "^2.74.0",
+    "selenium-webdriver": "^3.4.0",
     "sendgrid": "^5.1.0",
     "sharp": "^0.16.2",
     "socket.io": "^1.4.8",


### PR DESCRIPTION
The first step towards implementing Selenium testing in the project. Related to the parent issue #1217 

**Idea**
On every PR to the project, we will generate the event site (it can be anyone, currently I have set it to FOSSASIA 2016) and run a suite of functional tests against it. If the PR passes all the tests, it will pass else the Travis will fail.

**Changes**
* Run Selenium in Chromium browser (version 48) on Sauce Cloud.
* Add a very basic test to check the validity of the event name.

**Note**
* For better structure, readability, and scalability of the tests, we use [Selenium page objects model](https://watirmelon.blog/2015/10/30/webdriverjs-mocha-part-3-page-objects/). I will be working to incorporate that design into the tests and will soon open an issue consisting of a list of all the tests which we could run on the generated website.
* Also, we can change the browser to Firefox. Please guide on this.

**Test Link**
We can see the Travis logs to check whether the tests passed or not. Sauce Labs also provide us with a fantastic feature of watching the video of our tests. Since this is a very basic test, the video isn't that interesting and is very short. As we add more tests progressively, it will improve and its length will increase. 
https://saucelabs.com/beta/tests/7be5126fc8f147088cc9fcf061a9ebed/watch#4
