### PR TITLE
Improved search in the generated website

### DIFF
--- a/src/backend/templates/rooms.hbs
+++ b/src/backend/templates/rooms.hbs
@@ -310,7 +310,10 @@
                       $(this).find('.event').text().toUpperCase().indexOf(filterVal.toUpperCase()) < 0) {
                     $(this).hide();
                   } else {
-                    if($(this).is(':visible')) {
+                    if($(this).find('.tip-description').text().toUpperCase().indexOf(filterVal.toUpperCase()) >= 0 ||
+                        $(this).find('.session-speakers-list a span').text().toUpperCase().indexOf(filterVal.toUpperCase()) >= 0 ||
+                        $(this).find('.session-speakers-more').text().toUpperCase().indexOf(filterVal.toUpperCase()) >= 0 ||
+                        $(this).find('.event').text().toUpperCase().indexOf(filterVal.toUpperCase()) >= 0) {
                       flag = 0;
                       flagVenue = 0;
                       $(this).show();

--- a/src/backend/templates/schedule.hbs
+++ b/src/backend/templates/schedule.hbs
@@ -420,25 +420,29 @@
                   $(this).find('.time-filter').each(function() {
                       var flag = 1;
                       $(this).find('.track-inline').each(function() {
-                          if ($(this).find('.tip-description').text().toUpperCase().indexOf(filterVal.toUpperCase()) < 0 &&
-                              $(this).find('.session-speakers-list a p span').text().toUpperCase().indexOf(filterVal.toUpperCase()) < 0 &&
-                              $(this).find('.session-speakers-more').text().toUpperCase().indexOf(filterVal.toUpperCase()) < 0 &&
-                              $(this).find('.event').text().toUpperCase().indexOf(filterVal.toUpperCase()) < 0 &&
-                              $(this).find('.speaker-name').text().toUpperCase().indexOf(filterVal.toUpperCase()) < 0) {
-                               $(this).hide();
-                           } else {
-                             if($(this).is(':visible')) {
-                                 flag = 0;
-                                 $(this).show();
-                             }
-                           }
-                      });
-                      if (flag == 1) {
-                          $(this).hide();
-                      } else {
-                          temp = 0;
-                          $(this).show();
-                      }
+                            if ($(this).find('.tip-description').text().toUpperCase().indexOf(filterVal.toUpperCase()) < 0 &&
+                            $(this).find('.session-speakers-list a p span').text().toUpperCase().indexOf(filterVal.toUpperCase()) < 0 &&
+                            $(this).find('.session-speakers-more').text().toUpperCase().indexOf(filterVal.toUpperCase()) < 0 &&
+                            $(this).find('.event').text().toUpperCase().indexOf(filterVal.toUpperCase()) < 0 &&
+                            $(this).find('.speaker-name').text().toUpperCase().indexOf(filterVal.toUpperCase()) < 0) {
+                                $(this).hide();
+                            } else {
+                                if ($(this).find('.tip-description').text().toUpperCase().indexOf(filterVal.toUpperCase()) >= 0 ||
+                                $(this).find('.session-speakers-list a p span').text().toUpperCase().indexOf(filterVal.toUpperCase()) >= 0 ||
+                                $(this).find('.session-speakers-more').text().toUpperCase().indexOf(filterVal.toUpperCase()) >= 0 ||
+                                $(this).find('.event').text().toUpperCase().indexOf(filterVal.toUpperCase()) >= 0 ||
+                                $(this).find('.speaker-name').text().toUpperCase().indexOf(filterVal.toUpperCase()) >= 0) {
+                                    flag = 0;
+                                    $(this).show();
+                                }
+                            }
+                        });
+                        if (flag == 1) {
+                            $(this).hide();
+                        } else {
+                            temp = 0;
+                            $(this).show();
+                        }
                   });
                   if (temp == 1) {
                       $(this).hide();

--- a/src/backend/templates/speakers.hbs
+++ b/src/backend/templates/speakers.hbs
@@ -196,7 +196,8 @@
                         if ($(this).find('.speaker-name').text().toUpperCase().indexOf(filterVal.toUpperCase()) < 0 &&
                             $(this).find('.pop-over').text().toUpperCase().indexOf(filterVal.toUpperCase()) < 0) {
                              $(this).parent().hide();
-                         } else {
+                    } else if ($(this).find(".speaker-name").text().toUpperCase().indexOf(filterVal.toUpperCase()) >= 0 ||
+                                    $(this).find(".pop-over").text().toUpperCase().indexOf(filterVal.toUpperCase()) >= 0)  {
                              $(this).parent().show();
                          }
                     });

--- a/src/backend/templates/tracks.hbs
+++ b/src/backend/templates/tracks.hbs
@@ -305,7 +305,10 @@
                   $(this).find('.event').text().toUpperCase().indexOf(filterVal.toUpperCase()) < 0) {
                 $(this).hide();
               } else {
-                if ($(this).is(':visible')) {
+                if ($(this).find('.tip-description').text().toUpperCase().indexOf(filterVal.toUpperCase()) >= 0 ||
+                   $(this).find('.session-speakers-list a span').text().toUpperCase().indexOf(filterVal.toUpperCase()) >= 0 ||
+                   $(this).find('.session-speakers-more').text().toUpperCase().indexOf(filterVal.toUpperCase()) >= 0 ||
+                   $(this).find('.event').text().toUpperCase().indexOf(filterVal.toUpperCase()) >= 0) {
                   flag = 0;
                   flagTrack = 0;
                   $(this).show();


### PR DESCRIPTION
Fixes [#1304]

The search in schedule, tracks, speakers & rooms page was a little faulty. 

e.g. If you search "Keynote", then you get the results as soon as you type till "Keyn" and obviously when you type "keynde", you won't get the results. But when you erase the added wrong characters and search string becomes "Keyn", you still don't get results even after writing full search string "keynote", you won't get the results. Here is the gif showing the error. Please open to see the error.

![errorinsearch](https://cloud.githubusercontent.com/assets/13533873/26685827/d243391e-4708-11e7-8f1c-8b7cb1bf16e3.gif)

This PR fixes that error.

Before Changes:
[https://demolp.github.io/FOSSASIASummit/index.html](https://demolp.github.io/FOSSASIASummit/index.html)

After Changes:
[https://demolp.github.io/FOSSASIAnew/index.html](https://demolp.github.io/FOSSASIAnew/index.html)
