### PR TITLE
Fixed the crash of app when the long_biography field in the speaker s…

### DIFF
--- a/src/backend/fold.js
+++ b/src/backend/fold.js
@@ -48,6 +48,10 @@ function returnTrackFontColor(trackInfo, id) {
 }
 
 function checkNullHtml(html) {
+  if(html === undefined) {
+    return true;
+  }
+
   html = html.replace(/<\/?[^>]+(>|$)/g, "").trim();
   return (html === '');
 }

--- a/src/backend/fold.js
+++ b/src/backend/fold.js
@@ -951,3 +951,4 @@ module.exports.getOrganizerName = getOrganizerName;
 module.exports.foldBySpeakers = foldBySpeakers;
 module.exports.foldByTime = foldByTime;
 module.exports.returnTracknames = returnTracknames;
+module.exports.checkNullHtml = checkNullHtml;

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -131,6 +131,21 @@ describe('fold', function() {
       assert.equal(fold.getAppName(data.event.json), 'FOSSASIA 2016');
     });
   });
+  describe('.checkNullHtml()', () => {
+
+    it('should return true when the html passed doesn\'t contain info', () => {
+      assert.equal(fold.checkNullHtml('<p></p>'), true);
+    });
+
+    it('should return true when the argument passed is undefined', () => {
+      assert.equal(fold.checkNullHtml(), true);
+    });
+
+    it('should return false when the html contains info', () => {
+      assert.equal(fold.checkNullHtml('<p> I like writing tests </p>'), false);
+    });
+
+  })
 });
 
 describe('app',  () =>  {


### PR DESCRIPTION
…ection is missing

Fixes #1324 

Changes:
* Fix the crashing of the app when a zip file was used in which the `long_biography` field in the speaker section was undefined.

**Test Server**: https://peaceful-earth-19050.herokuapp.com
