### PR TITLE
Show all sessions on all the three pages: rooms, tracks and schedule

### DIFF
--- a/src/backend/assets/js/tabs.js
+++ b/src/backend/assets/js/tabs.js
@@ -16,9 +16,6 @@ tabs = function(options) {
         $(tabNavigationLinks[activeIndex]).removeClass('is-active');
         $(tabContentContainers[activeIndex]).removeClass('is-active');
       }
-      date = $('.' + $(tabNavigationLinks[index]).attr('id'));
-      $('.date-filter').addClass('hide');
-      $(date).removeClass('hide');
       $(tabNavigationLinks[index]).addClass('is-active');
       $(tabContentContainers[index]).addClass('is-active');
       activeIndex = index;

--- a/src/backend/templates/rooms.hbs
+++ b/src/backend/templates/rooms.hbs
@@ -79,11 +79,7 @@
         <div id="content-block" class="col-md-9">
           <div id="track-list">
             {{#roomsinfo}}
-            {{#if @first}}
               <div class="{{slug}} date-filter" id="rooms-list">
-              {{else}}
-              <div class="{{slug}} date-filter hide" id="rooms-list">
-            {{/if}}
                 <div class="row paddingzero">
                   <div class="col-md-12 paddingzero">
                     <h5 class="text">{{date}}</h4>

--- a/src/backend/templates/schedule.hbs
+++ b/src/backend/templates/schedule.hbs
@@ -93,11 +93,7 @@
         <div id="track-list" class="container">
 
           {{#timeList}}
-          {{#if @first}}
-            <div class="{{slug}} day-filter">
-            {{else}}
-            <div class="{{slug}} day-filter hide">
-          {{/if}}
+           <div class="{{slug}} day-filter">
             <div class="col-md-12 paddingzero">
               <h4 class="text">{{date}}</h4>
             </div>
@@ -530,9 +526,10 @@
               } else {
                 $('.day-filter').each(function () {
                   if($(this).attr('class').split(' ')[0] === className) {
-                    $(this).removeClass('hide');
-                  } else {
-                    $(this).addClass('hide');
+                    var elem = $(this);
+                    $('html,body').animate({
+                      scrollTop: elem.offset().top
+                    }, 500);
                   }
                 });
               }

--- a/src/backend/templates/tracks.hbs
+++ b/src/backend/templates/tracks.hbs
@@ -72,11 +72,7 @@
           <div id="content-block" class="col-md-9">
             <div id="track-list">
               {{#days}}
-                {{#if @first}}
-                  <div class="{{firstSlug}} date-filter">
-                {{else}}
-                  <div class="{{firstSlug}} date-filter hide">
-                {{/if}}
+               <div class="{{firstSlug}} date-filter">
                 <div class="row paddingzero">
                   <div class="col-md-12 paddingzero">
                     <h5 class="text">{{caption}}</h4>


### PR DESCRIPTION
Fixes #1327 

Changes:
* All the sessions from all the days are displayed on the three pages (tracks, rooms, and schedule) now.

**Test Link**
https://princu7.github.io/websiteTest
@aayusharora @geekyd Please review. Thanks!
