### PR TITLE
Fixed error which prevents appearance of sponsors pictures when the so…

### DIFF
--- a/src/backend/assets/dependencies/tweets.js
+++ b/src/backend/assets/dependencies/tweets.js
@@ -13,6 +13,10 @@ function interval() {
 }
 
 var datafetcher = function () {
+  if(tweetP === null) {
+    return;
+  }
+
   loklakFetcher.getTweets({}, datahandler);
 };
 


### PR DESCRIPTION
…cial links did not contain twitter

Fixes #1340 

Changes:
* Makes the sponsor's pictures visible and prevent Javascript error when the social links section of an event did not contain Twitter.
* The sponsor's images are not directly fetched but rather in a lazy manner with the help of javascript. Now, since there was no twitter link, the function related to the fetching of tweets was crashing leading to the error and hence the sponsor images were not being loaded. Thanks, @mahikaw for finding that issue.

**Test Server**:
http://secure-meadow-20680.herokuapp.com

Screenshots for the change: 
* Before
![screenshot from 2017-06-16 17-40-46](https://user-images.githubusercontent.com/8847265/27230143-e9387b4c-52cb-11e7-938b-42a2f9a3f333.png)
* After
![screenshot from 2017-06-16 17-07-06](https://user-images.githubusercontent.com/8847265/27230228-294ba39e-52cc-11e7-86a7-db9c6bd17ac1.png)

@aayusharora @geekyd Please review. Thanks!!