### PR TITLE
Tracks font color are now being followed on the speaker page

### DIFF
--- a/src/backend/templates/speakers.hbs
+++ b/src/backend/templates/speakers.hbs
@@ -166,7 +166,7 @@
                     </strong>
                   </h5>
                   <a href="tracks.html#{{session_id}}">
-                   <h4 style="background-color:{{{color}}};"  class="sizeevent event">
+                    <h4 style="background-color:{{{color}}}; color:{{{font_color}}}"  class="sizeevent event">
                     <span class="time-track">{{start}} - {{end}}&nbsp;&bull;&nbsp;</span>
                       <span>{{{title}}}</span>
                     </h4>


### PR DESCRIPTION
Fixes #1343 

**Changes**:
* Made the tracks font color which was not being shown on the speaker page, visible. Earlier, only the black color was used for the title of the session irrespective of the track to which it belonged to.

**Screenshots for the change**: 
* Before
![screenshot from 2017-06-17 11-38-16](https://user-images.githubusercontent.com/8847265/27250671-a7c10b98-5352-11e7-854f-f47ca9ea5fe9.png)
* After
![screenshot from 2017-06-17 11-40-55](https://user-images.githubusercontent.com/8847265/27250677-b023ef12-5352-11e7-9f39-622b13d52f29.png)
@aayusharora @geekyd Please review. Thanks 



