### PR TITLE
Added instagram icon as one of the event social link

### DIFF
--- a/src/backend/fold.js
+++ b/src/backend/fold.js
@@ -409,6 +409,9 @@ function createSocialLinks(event) {
       case 'google plus':
         link.icon = 'google-plus';
         break;
+      case 'instagram':
+        link.icon = 'instagram';
+        break;
       default:
         link.show = false;
         break;


### PR DESCRIPTION
Partially fixes the issue #1345 

**Changes**:
* Instagram link was not shown as one of the event links. Added it to the web app.

**Screenshots for the change**: 
![screenshot from 2017-06-18 17-11-14](https://user-images.githubusercontent.com/8847265/27260419-833668b6-5449-11e7-9478-27f741f27db9.png)

There is an Instagram link at the top-right corner.

**Test Server**
https://secure-meadow-20680.herokuapp.com

