### PR TITLE
Fix the misalignment of pop-up box in calendar view on the schedule page

### DIFF
--- a/src/backend/templates/schedule.hbs
+++ b/src/backend/templates/schedule.hbs
@@ -254,7 +254,7 @@
                         <span>{{venue}}</span>
                       {{/if}}
                     </div>
-                    <div class="session-container">
+                    <div>
                       {{#sessions}}
                         <div class="session" style="top:{{{top}}}px; height:{{{height}}}px;background-color:{{{color}}};
                           color: {{{font_color}}};">


### PR DESCRIPTION
Fixes  #1350 

**Changes**:
* Fix the alignment in the pop-up box in calendar view on the schedule page.

**Screenshots for the change**: 
![screenshot from 2017-06-19 07-25-02](https://user-images.githubusercontent.com/8847265/27266680-9df31880-54c0-11e7-9068-190c5830bd49.png)

**Test-Server**:-
http://secure-meadow-20680.herokuapp.com

@geekyd Please review. Thanks!!

