### PR TITLE
Default avatar for missing featured speaker images

### DIFF
--- a/src/backend/templates/event.hbs
+++ b/src/backend/templates/event.hbs
@@ -96,7 +96,11 @@
                       <div class="speaker-with-bio">
                         <div class="speaker">
                           <div class="image-holder">
-                            <img  onError="this.onerror=null;this.src='./images/avatar.png';" data-original="{{{photo}}}" class="lazy background-image" alt="{{{name}}}">
+                            {{#if photo}}
+                              <img  onError="this.onerror=null;this.src='./images/avatar.png';" data-original="{{{photo}}}" class="lazy background-image" alt="{{{name}}}">
+                            {{else}}
+                              <img class="background-image" alt="{{{name}}}" src="images/avatar.png"/>
+                            {{/if}}
                             <div class="responsive-overlay">
                               <div class="hover-state text-center preserve3d">
                                 <div class="social-links vertical-align">


### PR DESCRIPTION
Partially fixes the issue #1338 

**Changes**:
* Earlier, no default avatar image was being shown when the photo of a featured speaker was missing. Instead, a white space was shown on the front page. Corrected it and now a default avatar is shown.

**Screenshots for the change**: 
![screenshot from 2017-06-19 11-30-49](https://user-images.githubusercontent.com/8847265/27271613-547b2814-54e3-11e7-8d89-a93bb834f554.png)

**Test Server**:
https://secure-meadow-herokuapp.com

@aayusharora @geekyd Please review. Thanks :)

