### PR TITLE
Generate CNAME at time of deployment to Github Pages for redir…

### DIFF
--- a/gh_deploy.sh
+++ b/gh_deploy.sh
@@ -32,6 +32,8 @@ git remote add upstream "https://$GH_TOKEN@github.com/"${TRAVIS_REPO_SLUG}".git"
 git fetch upstream
 git reset upstream/gh-pages
 
+echo $GH_CNAME > CNAME
+
 touch .
 
 git add -A .


### PR DESCRIPTION
…ection to custom domain

Changes: 
* The CNAME created in the GH-pages branch will get deleted every time when we deploy to the Github Pages through the existing script.  Added the generation of the CNAME file in the deploy script for proper redirection.

@niranjan94 @mariobehling @aayusharora Please review. Thanks :)
