### PR TITLE
Show tweets only made by the organizer

### DIFF
--- a/src/backend/assets/dependencies/loklak-fetcher.js
+++ b/src/backend/assets/dependencies/loklak-fetcher.js
@@ -61,7 +61,7 @@ window.loklakFetcher = (function() {
       }
 
       if(dataset.from) {
-        query = query + "&from:" + dataset.from;
+        query = "from:" + dataset.from;
       }
 
       // Write unset options as their default


### PR DESCRIPTION
Fixes #1363 

Changes: 
* Now, only tweets made by the Mozilla will be shown.

**Test-Server**
http://peaceful-earth-19050.herokuapp.com

**Showcase Site**:-
https://princu7.github.io/open-event-webapp

@mariobehling @aayusharora @geekyd Please review. Thanks :)
