### PR TITLE
Remove horizontal scrollbars when the content of tweet become too large

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -1270,6 +1270,10 @@ a {
   }
 }
 
+#tweet {
+  word-break: break-all;
+}
+
 @media screen and (max-width : 600px) {
   .tweets-feed {
     font-size : 1em;


### PR DESCRIPTION
Fixes #1367 

Changes: 
* Earlier, when the tweet contained a link which got too big, then the content would overflow which would then introduce horizontal scrollbars on the page which looked bad. This effect was pretty visible on the smaller screens.

Screenshots for the change: 
![screenshot from 2017-06-23 17-30-49](https://user-images.githubusercontent.com/8847265/27481425-2b271126-583a-11e7-9918-48be8b425379.png)
![screenshot from 2017-06-23 17-30-57](https://user-images.githubusercontent.com/8847265/27481438-38313414-583a-11e7-9055-370c69165212.png)
@aayusharora @geekyd Please review. Thanks :)

