### PR TITLE
Fix a typo on the event showcase site

### DIFF
--- a/src/backend/overviewSite/index.html
+++ b/src/backend/overviewSite/index.html
@@ -61,7 +61,7 @@
 <div class="jumbotron">
   <div class="container text-center">
     <h1>Open Event Web Apps</h1>
-    <p>The <a href="https://webgen.eventyay.com"> Open Event Web App Generator </a>uses the <a href="https://github.com/fossasia/open-event"> Open Event format </a> to generate static websites of events. Feast your eyes on our beautiful examples events.</p>
+    <p>The <a href="https://webgen.eventyay.com"> Open Event Web App Generator </a>uses the <a href="https://github.com/fossasia/open-event"> Open Event format </a> to generate static websites of events. Feast your eyes on our beautiful example events.</p>
   </div>
 </div>
 


### PR DESCRIPTION
Fixes #1362 completely

Changes:
* Correct the typo in the description of the showcase site.

@aayusharora @geekyd Please review. Thanks :)
