### PR TITLE
Fix the issue when the schedule of the current selected date was not …

### DIFF
--- a/src/backend/templates/schedule.hbs
+++ b/src/backend/templates/schedule.hbs
@@ -528,44 +528,78 @@
             display();
           });
 
-          $('.date-button').click(function() {
-              let className = $(this).attr('class').split(' ')[0];
-              $(this).addClass('is-active');
-              $(this).siblings().removeClass('is-active');
+          function getCurrentDate() {
+            var className = '';
 
-              if(isCalendarView) {
-                $('.calendar').each(function () {
-                  if($(this).attr('class').split(' ')[0] === className) {
-                    $(this).removeClass('hide');
-                  } else {
-                    $(this).addClass('hide');
-                  }
-                });
-              } else {
-                $('.day-filter').each(function () {
-                  if($(this).attr('class').split(' ')[0] === className) {
-                    $(this).removeClass('hide');
-                  } else {
-                    $(this).addClass('hide');
-                  }
-                });
+            $('.date-button').each(function() {
+              if($(this).hasClass('is-active')) {
+                className = $(this).attr('class').split(' ')[0];
               }
             });
+            return className;
+          }
+
+          function viewsFilter(curView, date) {
+            if(curView === 'list') {
+              $('.day-filter').each(function () {
+                if($(this).attr('class').split(' ')[0] === date) {
+                  $(this).removeClass('hide');
+                } else {
+                  $(this).addClass('hide');
+                }
+              });
+            }
+            else if(curView === 'calendar') {
+              $('.calendar').each(function () {
+                if($(this).attr('class').split(' ')[0] === date) {
+                  $(this).removeClass('hide');
+                } else {
+                  $(this).addClass('hide');
+                }
+              });
+            }
+          }
+
+          $('.date-button').click(function() {
+            let className = $(this).attr('class').split(' ')[0];
+
+            $(this).addClass('is-active');
+            $(this).siblings().removeClass('is-active');
+
+            if(isCalendarView) {
+              viewsFilter('calendar', className);
+            } else {
+              viewsFilter('list', className);
+            }
+
+          });
 
           $('#calendar').click(function() {
+            var curDate = getCurrentDate();
+
             isCalendarView = true;
             $('#list').addClass('unselect').removeClass('view-active');
             $('#calendar').removeClass('unselect').addClass('view-active');
             $('.list-view').addClass('hide');
             $('.calendar-view').removeClass('hide');
+
+            if(curDate !== '') {
+              viewsFilter('calendar', curDate);
+            };
           });
 
           $('#list').click(function() {
+            var curDate = getCurrentDate();
+
             isCalendarView = false;
             $('#list').removeClass('unselect').addClass('view-active');
             $('#calendar').addClass('unselect').removeClass('view-active');
             $('.list-view').removeClass('hide');
             $('.calendar-view').addClass('hide');
+
+            if (curDate !== '') {
+              viewsFilter('list', curDate);
+            }
           });
 
           $(".export-png").click(function() {


### PR DESCRIPTION
…shown on changing the view from list to schedule and vice-versa

Fixes #1371 

Changes:
* Earlier, when a particular date of the event was selected and the view (list to calendar or vice-versa) of the schedule was changed, the currently selected date was not retained and in the changed view, the schedule of the first day would be shown. Corrected this mistake, and now on changing views, the currently selected date is followed.

Screenshots for the change: 
* Selecting a date in list view
![screenshot from 2017-06-26 12-49-23](https://user-images.githubusercontent.com/8847265/27528610-d118e146-5a6e-11e7-8145-d11c0b74ea4d.png)
* Changing to Calendar view (date retained)
![screenshot from 2017-06-26 12-49-28](https://user-images.githubusercontent.com/8847265/27528609-d116247e-5a6e-11e7-8fa4-2cbee399a9a6.png)
* Changing date in calendar view
![screenshot from 2017-06-26 12-49-34](https://user-images.githubusercontent.com/8847265/27528611-d1241b10-5a6e-11e7-88d2-ead44d10b0cc.png)
* Switching to list view (date retained)
![screenshot from 2017-06-26 12-49-39](https://user-images.githubusercontent.com/8847265/27528612-d1294932-5a6e-11e7-9687-7c15bcfe02bf.png)

Test-Server:- http://secure-meadow-20680.herokuapp.com

@aayusharora @geekyd Please review. Thanks :)

