### PR TITLE
Corrected track-list wrapping problem

### DIFF
--- a/src/backend/templates/tracks.hbs
+++ b/src/backend/templates/tracks.hbs
@@ -243,7 +243,7 @@
               {{/days}}
             </div>
           </div>
-          <div class="track-names">
+          <div class="track-names col-md-9" >
             {{#tracknames}}
               {{#if title}}
                 <ul class="title-inline title-legend">


### PR DESCRIPTION
Fixes #1356
Changes: The track-list div was styled similar to content-block div so that it doesn't wrap around the parent container.

Screenshots for the change: 
![screenshot from 2017-06-29 01-19-12](https://user-images.githubusercontent.com/21010060/27657075-06ab6666-5c69-11e7-94da-735cf0940a09.png)

@aayusharora @Princu7 please review.