### PR TITLE
fixes UI issues in sponsors and track-list

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -352,11 +352,13 @@ a {
 }
 
 .sponsor-row {
-  margin: 0;
   font-weight: bold;
   color: black;
-  margin-top: 100px;
-  margin-bottom: 100px;
+}
+
+.sponsor-row-text {
+  margin-bottom: 60px;
+  margin-top: 10px;
 }
 
 .sponsors {
@@ -371,6 +373,11 @@ a {
 
 .location {
   background-color: $white-classic-background;
+}
+
+.location-map {
+  margin-left: 0;
+  margin-right: 0
 }
 
 .address {
@@ -1823,11 +1830,6 @@ a.skip:hover {
   border-color:$light-black;
   margin: 0;
   width: 100%;
-}
-
-
-#content-block {
-  margin: 15px 0 0 15px;
 }
 
 #track-list {

--- a/src/backend/templates/event.hbs
+++ b/src/backend/templates/event.hbs
@@ -176,7 +176,7 @@
               <div class="row">
                 {{#each sponsorpics}}
                   {{#each this}}
-                    <div class="{{{divclass}}}">
+                    <div class="sponsor-row-text {{{divclass}}}">
                       <div class=" {{{sponsorimg}}} text-center">
                         <a href="{{{url}}}" data-toggle="tooltip" title="{{{type}}}">
                           <img class="lazy centre {{{imgsize}}}" alt="{{{name}}}" data-original="{{{logo}}}">
@@ -196,7 +196,7 @@
     {{#if eventurls.latitude }}
       {{#if eventurls.longitude}}
         <div class="location">
-          <div class="sponsor-row row">
+          <div class="location-map row">
             <div class="col-md-8" id="map">
             </div>
             <div class="address col-md-4">

--- a/src/backend/templates/tracks.hbs
+++ b/src/backend/templates/tracks.hbs
@@ -235,7 +235,7 @@
               {{/days}}
             </div>
           </div>
-          <div class="track-names col-md-9" >
+          <div class="track-names col-md-3" >
             {{#tracknames}}
               {{#if title}}
                 <ul class="title-inline title-legend">


### PR DESCRIPTION
Fixes #1381 

Changes: 

- Sponsor images and titles appear in a proper alignment now.

- The tracks list don't wrap or move to the end in any case(if the sessions are too less or more than the track-lists at the right)

Screenshots for the change: 

<img width="1370" alt="screen shot 2017-07-03 at 3 43 16 pm" src="https://user-images.githubusercontent.com/21010060/27788608-f274b7dc-6006-11e7-95e9-f2c8183e3484.png">

<img width="1376" alt="screen shot 2017-07-03 at 3 49 23 pm" src="https://user-images.githubusercontent.com/21010060/27788694-3a6b89e4-6007-11e7-89bb-1113c115854b.png">

<img width="1279" alt="screen shot 2017-07-03 at 3 43 36 pm" src="https://user-images.githubusercontent.com/21010060/27788611-f4c75238-6006-11e7-85e2-c6586215df45.png">

----

@aayusharora @Princu7 Please review.