### PR TITLE
Add bookmark test on schedule and rooms page

### DIFF
--- a/src/selenium/roomPage.js
+++ b/src/selenium/roomPage.js
@@ -1,0 +1,29 @@
+var BasePage = require('./basePage.js');
+var By = require('selenium-webdriver').By;
+var until = require('selenium-webdriver').until;
+
+var RoomPage = Object.create(BasePage);
+
+RoomPage.checkIsolatedBookmark = function() {
+
+  // We go into starred mode and unmark sessions having id 3015 which was marked previously on tracks pages. If the bookmark feature works, then length of the web page would decrease.
+
+  var getPageHeight = 'return document.body.scrollHeight';
+  var sessionIdsArr = ['3015'];
+  var self = this;
+  var oldHeight, newHeight;
+
+  return self.toggleStarredButton().then(function() {
+    return self.driver.executeScript(getPageHeight).then(function(height) {
+      oldHeight = height;
+      return self.toggleSessionBookmark(sessionIdsArr).then(function() {
+        return self.driver.executeScript(getPageHeight).then(function(height) {
+          newHeight = height;
+          return oldHeight > newHeight;
+        });
+      });
+    });
+  });
+};
+
+module.exports = RoomPage;

--- a/src/selenium/schedulePage.js
+++ b/src/selenium/schedulePage.js
@@ -1,0 +1,29 @@
+var BasePage = require('./basePage.js');
+var By = require('selenium-webdriver').By;
+var until = require('selenium-webdriver').until;
+
+var SchedulePage = Object.create(BasePage);
+
+SchedulePage.checkIsolatedBookmark = function() {
+
+  // We go into starred mode and unmark sessions having id 3014 which was marked previously on tracks pages. If the bookmark feature works, then length of the web page would decrease.
+
+  var self = this;
+  var getPageHeight = 'return document.body.scrollHeight';
+  var sessionIdsArr = ['3014'];
+  var oldHeight, newHeight;
+
+  return self.toggleStarredButton().then(function() {
+    return self.driver.executeScript(getPageHeight).then(function(height) {
+      oldHeight = height;
+      return self.toggleSessionBookmark(sessionIdsArr).then(function() {
+        return self.driver.executeScript(getPageHeight).then(function(height) {
+          newHeight = height;
+          return oldHeight > newHeight;
+        });
+      });
+    });
+  });
+};
+
+module.exports = SchedulePage;

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -19,6 +19,8 @@ var app = require('../src/app');
 var webdriver = require('selenium-webdriver');
 var eventPage = require('../src/selenium/eventPage.js');
 var trackPage = require('../src/selenium/trackPage.js');
+var schedulePage = require('../src/selenium/schedulePage.js');
+var roomPage = require('../src/selenium/roomPage.js');
 var By = webdriver.By;
 var fs = require('fs');
 
@@ -367,6 +369,42 @@ describe("Running Selenium tests on Chrome Driver", function() {
     it('Checking the bookmark toggle', function(done) {
       trackPage.checkIsolatedBookmark().then(function(num) {
         assert.equal(num, 2);
+        done();
+      }).catch(function(err) {
+        done(err);
+      });
+    });
+
+  });
+
+  describe('Testing schedule page', function() {
+
+    before(function() {
+      schedulePage.init(driver);
+      schedulePage.visit('http://localhost:5000/live/preview/a@a.com/FOSSASIASummit/schedule.html');
+    });
+
+    it('Checking the bookmark toggle', function(done) {
+      schedulePage.checkIsolatedBookmark().then(function(val) {
+        assert.equal(val, 1);
+        done();
+      }).catch(function(err) {
+        done(err);
+      });
+    });
+
+  });
+
+  describe('Testing rooms page', function() {
+
+    before(function() {
+      roomPage.init(driver);
+      roomPage.visit('http://localhost:5000/live/preview/a@a.com/FOSSASIASummit/schedule.html');
+    });
+
+    it('Checking the bookmark toggle', function(done) {
+      roomPage.checkIsolatedBookmark().then(function(val) {
+        assert.equal(val, 1);
         done();
       }).catch(function(err) {
         done(err);


### PR DESCRIPTION
Partially fixes the parent issue #1311 

**Changes**:
* Implements the bookmark testing on rooms and schedule pages also.

* Testing all the session elements whether they are visible or not (done on the tracks pages) takes a lot of time. So, I have used a different approach here. We had already marked two elements on the tracks page. We, then go to the schedule page and go into the starred mode. We calculate the current height of the page. We then unmark a session and then recalculate the height of the page again. If the bookmark feature is working, then the height should decrease. I have followed the same approach on the rooms pages too. While this is not absolutely perfect, it is a good way to check the feature. We have already employed the perfect method on the tracks page so there was no need of applying it on the schedule and the rooms page since it would have increased the time of the testing by a quite large margin.

**Video to Demonstrate**:
https://saucelabs.com/beta/tests/613c4e36631243fc93864d5e9e4f53da/watch#270

@aayusharora @geekyd @sumedh123 @anu-007 @arp95 @mahikaw Please review. Thanks :)

