### PR TITLE
Added codecov.yml and ignored selenium test scripts folder

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach, diff, flags, files, footer"
+  behavior: default
+  require_changes: no
+
+ignore:
+  - "src/selenium"


### PR DESCRIPTION
Fixes #1391 

Changes:
* Add the codecov.yml file and excluded Selenium Test scripts from the coverage since it doesn't make much sense to track the test scripts themselves.
