### PR TITLE
Tracks in tracklist on the right hand side  appear in sorted order

### DIFF
--- a/src/backend/fold.js
+++ b/src/backend/fold.js
@@ -363,7 +363,7 @@ function returnTracknames(sessions, trackInfo) {
         title: session.track.name,
         color: returnTrackColor(trackDetails, (session.track == null) ? null : session.track.id),
         font_color: returnTrackFontColor(trackDetailsFont, (session.track === null) ? null : session.track.id),
-        sortKey: moment.parseZone(session.start_time).format('YY-MM-DD'),
+        sortKey: session.track.name,
         slug: slug
       };
       trackData.set(slug, track);


### PR DESCRIPTION
Fixes #1353 

Changes: They appear in alphabetical order now.

Screenshots for the change: 


<img width="1271" alt="screen shot 2017-07-16 at 12 47 29 am" src="https://user-images.githubusercontent.com/21010060/28242187-e212767a-69c2-11e7-9f3a-73b1acf8ab3f.png">

@aayusharora @Princu7 Please review.