### PR TITLE
Jump to Track page on Clicking session of a speaker

### DIFF
--- a/src/selenium/speakerPage.js
+++ b/src/selenium/speakerPage.js
@@ -9,5 +9,24 @@ SpeakerPage.searchTest = function() {
   return this.commonSearchTest('Mario', idList);
 };
 
+SpeakerPage.jumpToTrack = function() {
+  var self = this;
+  var speakerId = '2330';
+  var pageVertScrollOffset = 'return window.scrollY';
+
+  var trackPromise =  new Promise(function(resolve) {
+    self.find(By.id(speakerId)).then(function(elem) {
+      self.driver.actions().mouseMove(elem).perform();
+      elem.findElement(By.className('sessions')).findElement(By.css('a')).click().then(self.getPageUrl.bind(self))
+        .then(function(url) {
+          self.driver.executeScript(pageVertScrollOffset).then(function(height) {
+            resolve(height > 0 && (url.search('tracks') != -1));
+        });
+      });
+    });
+  });
+
+  return trackPromise;
+};
 
 module.exports = SpeakerPage;

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -620,5 +620,14 @@ describe("Running Selenium tests on Chrome Driver", function() {
       });
     });
 
+    it('Jump to track page on clicking session of a speaker', function(done) {
+      speakerPage.jumpToTrack().then(function(val) {
+        assert.equal(val, 1);
+        done();
+      }).catch(function(err) {
+        done(err);
+      });
+    });
+
   });
 });


### PR DESCRIPTION
**Partially Fixes** the issue #1311 

**Changes**:
* Add test for checking whether the user is redirected to the appropriate track on the tracks page on clicking the session of a particular speaker. 

**Video for Demonstration**
https://saucelabs.com/beta/tests/e996246190d240048f9dc5f1fc9230aa/watch#543
The jump would be around the end of the video. Around 15 seconds before it.

@aayusharora @geekyd @sumedh123 @anu-007 Please review. Thanks :)
