### PR TITLE
Fix overlapping of contact mail and icon

### DIFF
--- a/src/backend/templates/partials/footer.hbs
+++ b/src/backend/templates/partials/footer.hbs
@@ -48,11 +48,11 @@
         <li>
 
         <i class="fa fa-envelope"></i>
-          <span>
+          <div>
           <a href="mailto:{{eventurls.email}}" target="_self" class="org-name">
           {{eventurls.email}}
           </a>
-          </span>
+          </div>
 
 
         </li>
@@ -60,7 +60,7 @@
         {{#if eventurls.location}}
         <li class="address">
         <i class="fa fa-map-marker"></i>
-          <span>{{{eventurls.orgname}}}&#44;&nbsp;{{eventurls.location}}</span>
+          <div>{{{eventurls.orgname}}}&#44;&nbsp;{{eventurls.location}}</div>
         </li>
         {{/if}}
       </ul>


### PR DESCRIPTION
Fixes #1413 
 Span was not allowing the text to be properly postioned inside itself. Changed span tags to div. Works fine now.
Screenshots for the change: 
![screenshot from 2017-07-23 16-19-06](https://user-images.githubusercontent.com/22816171/28499091-54e3cff6-6fcb-11e7-8676-98b4310fbf34.png)


