### PR TITLE
Fix the border issue in the calendar view of the session schedule

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -1790,7 +1790,8 @@ a.skip:hover {
   @include cursorpointer;
   color: $white;
   position: absolute;
-  border: 1px solid $gray-extra-dark;
+  outline: 1px solid $gray-extra-dark;
+  padding: 5px;
   width: 100%;
   line-height: 120%;
   font-weight: bold;


### PR DESCRIPTION
Fixes #1416 

**Changes**:
* Fixes the border issue in the calendar view of the session schedule
* The border combined that's why the appearance was varied. The problem could be easily seen when we increase the border (eg: to 5px)

* 1px border
![screenshot from 2017-07-27 18-13-30](https://user-images.githubusercontent.com/8847265/28670754-bd1f2c44-72f7-11e7-93d2-0ef47f4b4074.png)

* 5px border
![screenshot from 2017-07-27 18-11-34](https://user-images.githubusercontent.com/8847265/28670692-76799f90-72f7-11e7-9eb4-271f5d0b637c.png)
As we can see, when two sessions are together, the width combine resulting in weird appearance.

**After the Fix**
![screenshot from 2017-07-27 18-13-49](https://user-images.githubusercontent.com/8847265/28670769-ca210e4e-72f7-11e7-9bb5-d75d1ca34b9a.png)

@aayusharora @geekyd @sumedh123 @mahikaw @arp95 @anu-007 Please review. Thanks!
