### PR TITLE
Fixes the Track name list position issue

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -1844,8 +1844,8 @@ a.skip:hover {
 }
 
 #content-block {
-   margin: 15px 0 0 15px;
- }
+  padding-left: 30px;
+}
 
 #track-list {
   margin-top:4%;
@@ -1870,16 +1870,6 @@ a.skip:hover {
 .schedule-margin {
   margin-right: 0;
   margin-bottom: 20px;
-}
-
-.list-view {
-  padding-left: 0;
-  padding-right: 0;
-}
-
-.calendar-view {
-  padding-left: 0;
-  padding-right: 0;
 }
 
 .left-border {

--- a/src/backend/templates/rooms.hbs
+++ b/src/backend/templates/rooms.hbs
@@ -244,7 +244,7 @@
               {{/roomsinfo}}
             </div>
           </div>
-          <div class="track-names">
+          <div class="track-names col-md-3">
             {{#tracknames}}
               {{#if title}}
                 <ul class="title-inline title-legend">

--- a/src/backend/templates/schedule.hbs
+++ b/src/backend/templates/schedule.hbs
@@ -90,7 +90,7 @@
     </div>
 
     <div class="row">
-      <div id="content-block" class="col-md-9 list-view">
+      <div class="col-md-9 list-view">
         <div id="track-list" class="container">
 
           {{#timeList}}
@@ -223,7 +223,7 @@
           {{/timeList}}
         </div>
       </div>
-      <div id="content-block" class="col-md-12 calendar-view hide">
+      <div class="col-md-12 calendar-view hide">
         <div id="track-list" class="container">
         {{#roomsinfo}}
           {{#if @first}}
@@ -370,7 +370,7 @@
           {{/roomsinfo}}
         </div>
       </div>
-      <div class="track-names">
+      <div class="track-names col-md-3">
       {{#tracknames}}
       {{#if title}}
         <ul class="title-inline title-legend">

--- a/src/selenium/basePage.js
+++ b/src/selenium/basePage.js
@@ -245,6 +245,43 @@ var BasePage = {
       promiseArr.push(self.resizeWindow(size[0], size[1]).then(self.checkScrollbar.bind(self)));
     });
     return Promise.all(promiseArr);
+  },
+
+  getPos: function(el) {
+    return el.getLocation();
+  },
+
+  checkTrackNamePos: function() {
+    var self = this;
+
+    return self.find(By.className('track-names')).then(self.getPos).then(function(posObj) {
+      return posObj.y < 2000;
+    });
+  },
+
+  checkAlignment: function() {
+    var self = this;
+    var posPromArr = [];
+
+    posPromArr.push(self.find(By.id('tabs')).then(self.getPos));
+    posPromArr.push(self.find(By.className('text')).then(self.getPos));
+
+    var checkAlign = new Promise(function(resolve) {
+      Promise.all(posPromArr).then(function(posArr) {
+        resolve(Math.abs(posArr[0].x - posArr[1].x));
+      });
+    });
+
+  return checkAlign;
+  },
+
+  bookmarkCheck: function(sessionToggleArr, visCheckSessionArr) {
+    var self = this;
+    var sessionElemArr = visCheckSessionArr.map(function(id) {
+      return self.find(By.id(id));
+    });
+
+  return self.toggleSessionBookmark(sessionToggleArr).then(self.toggleStarredButton.bind(self)).then(self.getElemsDisplayStatus.bind(null, sessionElemArr));
   }
 
 };

--- a/src/selenium/roomPage.js
+++ b/src/selenium/roomPage.js
@@ -5,25 +5,11 @@ var until = require('selenium-webdriver').until;
 var RoomPage = Object.create(BasePage);
 
 RoomPage.checkIsolatedBookmark = function() {
-
-  // We go into starred mode and unmark sessions having id 3015 which was marked previously on tracks pages. If the bookmark feature works, then length of the web page would decrease.
-
-  var getPageHeight = 'return document.body.scrollHeight';
-  var sessionIdsArr = ['3015'];
   var self = this;
-  var oldHeight, newHeight;
+  var bookmarkSessionsIdsArr = ['3014'];
+  var visibleCheckSessionsIdsArr = ['3014', '3015', '2918'];
 
-  return self.toggleStarredButton().then(function() {
-    return self.driver.executeScript(getPageHeight).then(function(height) {
-      oldHeight = height;
-      return self.toggleSessionBookmark(sessionIdsArr).then(function() {
-        return self.driver.executeScript(getPageHeight).then(function(height) {
-          newHeight = height;
-          return oldHeight > newHeight;
-        });
-      });
-    });
-  });
+  return self.bookmarkCheck(bookmarkSessionsIdsArr, visibleCheckSessionsIdsArr);
 };
 
 RoomPage.toggleSessionElem = function() {

--- a/src/selenium/schedulePage.js
+++ b/src/selenium/schedulePage.js
@@ -6,25 +6,11 @@ var SchedulePage = Object.create(BasePage);
 var datesId = ['2017-03-17', '2017-03-18', '2017-03-19'];
 
 SchedulePage.checkIsolatedBookmark = function() {
-
-  // We go into starred mode and unmark sessions having id 3014 which was marked previously on tracks pages. If the bookmark feature works, then length of the web page would decrease.
-
   var self = this;
-  var getPageHeight = 'return document.body.scrollHeight';
-  var sessionIdsArr = ['3014'];
-  var oldHeight, newHeight;
+  var bookmarkSessionsIdsArr = ['3015'];
+  var visibleCheckSessionsIdsArr = ['3014', '3015', '2918'];
 
-  return self.toggleStarredButton().then(function() {
-    return self.driver.executeScript(getPageHeight).then(function(height) {
-      oldHeight = height;
-      return self.toggleSessionBookmark(sessionIdsArr).then(function() {
-        return self.driver.executeScript(getPageHeight).then(function(height) {
-          newHeight = height;
-          return oldHeight > newHeight;
-        });
-      });
-    });
-  });
+  return self.bookmarkCheck(bookmarkSessionsIdsArr, visibleCheckSessionsIdsArr);
 };
 
 SchedulePage.toggleSessionElem = function() {

--- a/src/selenium/trackPage.js
+++ b/src/selenium/trackPage.js
@@ -13,13 +13,11 @@ TrackPage.getNoOfVisibleSessionElems = function() {
 
 TrackPage.checkIsolatedBookmark = function() {
   // Sample sessions having ids of 3014 and 3015 being checked for the bookmark feature
-  var sessionIdsArr = ['3014', '3015'];
   var self = this;
+  var bookmarkSessionsIdsArr = ['3014', '3015'];
+  var visibleCheckSessionsIdsArr = ['3014', '3015', '2918'];
 
-  // Bookmark the sessions, scrolls down the page and then count the number of visible session elements
-  return self.toggleSessionBookmark(sessionIdsArr).then(self.toggleStarredButton.bind(self)).then(function() {
-    return self.driver.executeScript('window.scrollTo(0, 400)').then(self.getNoOfVisibleSessionElems.bind(self));
-  });
+  return self.bookmarkCheck(bookmarkSessionsIdsArr, visibleCheckSessionsIdsArr);
 };
 
 

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -406,6 +406,24 @@ describe("Running Selenium tests on Chrome Driver", function() {
       });
     });
 
+    it('Checking track name list appear near the top of page', function(done) {
+      trackPage.checkTrackNamePos().then(function(boolval) {
+        assert.equal(boolval, true);
+        done();
+      }).catch(function(err) {
+        done(err);
+      });
+    });
+
+    it('Checking horizontal alignment of date tab and session content below it', function(done) {
+      trackPage.checkAlignment().then(function(val) {
+        assert.equal(val, 0);
+        done();
+      }).catch(function(err) {
+        done(err);
+      });
+    });
+
     it('Checking subnavbar functionality', function(done) {
       trackPage.checkAllSubnav().then(function(boolArr) {
         trackPage.visit('http://localhost:5000/live/preview/a@a.com/FOSSASIASummit/tracks.html');
@@ -456,8 +474,8 @@ describe("Running Selenium tests on Chrome Driver", function() {
     });
 
     it('Checking the bookmark toggle', function(done) {
-      trackPage.checkIsolatedBookmark().then(function(num) {
-        assert.equal(num, 2);
+      trackPage.checkIsolatedBookmark().then(function(visArr) {
+        assert.deepEqual(visArr, [true, true, false]);
         done();
       }).catch(function(err) {
         done(err);
@@ -498,6 +516,24 @@ describe("Running Selenium tests on Chrome Driver", function() {
       schedulePage.getScrollbarVisibility(sizesArr).then(function(statusArr) {
         schedulePage.driver.manage().window().maximize();
         assert.deepEqual(statusArr, [false, false]);
+        done();
+      }).catch(function(err) {
+        done(err);
+      });
+    });
+
+    it('Checking track name list appear near the top of page', function(done) {
+      trackPage.checkTrackNamePos().then(function(boolval) {
+        assert.equal(boolval, true);
+        done();
+      }).catch(function(err) {
+        done(err);
+      });
+    });
+
+    it('Checking alignment of date tab and session content', function(done) {
+      trackPage.checkAlignment().then(function(val) {
+        assert.equal(val, 0);
         done();
       }).catch(function(err) {
         done(err);
@@ -600,8 +636,8 @@ describe("Running Selenium tests on Chrome Driver", function() {
 
     it('Checking the bookmark toggle', function(done) {
       schedulePage.visit('http://localhost:5000/live/preview/a@a.com/FOSSASIASummit/schedule.html');
-      schedulePage.checkIsolatedBookmark().then(function(val) {
-        assert.equal(val, 1);
+      schedulePage.checkIsolatedBookmark().then(function(visArr) {
+        assert.deepEqual(visArr, [true, false, false]);
         done();
       }).catch(function(err) {
         done(err);
@@ -622,6 +658,24 @@ describe("Running Selenium tests on Chrome Driver", function() {
       roomPage.getScrollbarVisibility(sizesArr).then(function(statusArr) {
         roomPage.driver.manage().window().maximize();
         assert.deepEqual(statusArr, [false, false]);
+        done();
+      }).catch(function(err) {
+        done(err);
+      });
+    });
+
+    it('Checking track name list appear near the top of page', function(done) {
+      trackPage.checkTrackNamePos().then(function(boolval) {
+        assert.equal(boolval, true);
+        done();
+      }).catch(function(err) {
+        done(err);
+      });
+    });
+
+    it('Checking alignment of date tab and session content', function(done) {
+      trackPage.checkAlignment().then(function(val) {
+        assert.equal(val, 0);
         done();
       }).catch(function(err) {
         done(err);
@@ -678,8 +732,8 @@ describe("Running Selenium tests on Chrome Driver", function() {
     });
 
     it('Checking the bookmark toggle', function(done) {
-      roomPage.checkIsolatedBookmark().then(function(val) {
-        assert.equal(val, 1);
+      roomPage.checkIsolatedBookmark().then(function(visArr) {
+        assert.deepEqual(visArr, [false, false, false]);
         done();
       }).catch(function(err) {
         done(err);


### PR DESCRIPTION
Fixes #1423 

**Changes**
* The track name list is now visible near the top of the page. Earlier, it went down to the bottom of the tracks page
* To make sure this issue doesn't ever happen again, added selenium tests for it
* Also, corrected some of the bookmark tests which were written in a slightly wrong manner and were failing after making the above changes

**Test Server**
http://secure-meadow-20680.herokuapp.com

**Video for Demonstration**
https://saucelabs.com/beta/tests/5e059ace942f4e0694ca8cf23654079e/watch#517

**Test Website**
https://princu7.github.io/websiteTest/index.html

@aayusharora @geekyd @sumedh123 Please review. Thanks :)

