### PR TITLE
Made the side track name list act as a session filter

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -802,6 +802,15 @@ a {
   border-radius: 50%;
   height: 12px;
   width: 12px;
+  display: inline-block;
+}
+
+.track-name {
+  cursor: pointer;
+}
+
+.track-info {
+  margin-bottom: 5px;
 }
 
 .title-inline {
@@ -826,6 +835,11 @@ a {
 .track-names {
   color: $black;
   margin-top: 16%;
+  padding-left: 30px;
+
+  @media screen and (max-width: 768px) {
+    margin-top: 0;
+  }
 }
 
 .social-buttons {
@@ -889,10 +903,6 @@ a {
   .title-legend {
     float: left;
     width: 40%;
-  }
-
-  .track-names {
-    margin-top: 0;
   }
 }
 
@@ -2043,3 +2053,14 @@ a.skip:hover {
   margin: 7.5px -15px;
 }
 
+#filterInfo {
+  display: none;
+  font-size: 18px;
+  margin-top:20px;
+  border: 1px dotted black;
+  background-color: #efefef;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  margin-left: 15px;
+  margin-right: 15px;
+}

--- a/src/backend/gulpfile.js
+++ b/src/backend/gulpfile.js
@@ -25,7 +25,7 @@ exports.minifyJs = function (path, cb) {
 
   gulp.task('tracksJs', function() {
 
-    return gulp.src([dir + 'social.js', dir + 'scroll.js', dir + 'navbar.js', dir + 'tabs.js', dir + 'jquery.lazyload.js'])
+    return gulp.src([dir + 'social.js', dir + 'scroll.js', dir + 'navbar.js', dir + 'jquery.lazyload.js'])
       .pipe(iife({ useStrict : false}))
       .pipe(concat('tracks.min.js'))
       .pipe(babel({ presets: ['es2015'] }))

--- a/src/backend/templates/tracks.hbs
+++ b/src/backend/templates/tracks.hbs
@@ -57,7 +57,13 @@
       text across the page.
       --------------------------------------------------------------- -->
       <div class="date-list container">
-        {{> subnavbar flag = 1}}
+        <div id="tabs" class="col-md-8 col-xs-12 col-sm-12 tabs no-js">
+          <span class="tabs-nav">
+            {{#days}}
+              <a href="./tracks.html#{{firstSlug}}" class="tabs-nav-link">{{caption}}</a>
+            {{/days}}
+          </span>
+        </div>
         <div class = "col-md-4 col-sm-12 col-xs-12 navbar-flex">
           <div class="search-filter search-filter-room filter-margin">
                <label for="search-input"><i class="fa fa-search" aria-hidden="true"></i></label>
@@ -69,12 +75,16 @@
           </div>
         </div>
       </div>
+      <div id="filterInfo" class="container">
+        TYPE: <span id="curFilter" style="font-weight:bold;"> </span> <a href="#" id="clearFilter">  [Clear Filter]</a>
+      </div>
       <div id="session-list" class="container">
         <div class="row">
-          <div id="content-block" class="col-md-9">
+          <div id="content-block" class="col-md-9 col-sm-9">
             <div id="track-list">
               {{#days}}
-               <div class="{{firstSlug}} date-filter">
+               <a class="anchor" id="{{firstSlug}}"></a>
+               <div class="date-filter">
                 <div class="row paddingzero">
                   <div class="col-md-12 paddingzero">
                     <h5 class="text">{{caption}}</h4>
@@ -235,13 +245,13 @@
               {{/days}}
             </div>
           </div>
-          <div class="track-names col-md-3" >
+          <div class="track-names col-md-3 col-sm-3">
             {{#tracknames}}
               {{#if title}}
-                <ul class="title-inline title-legend">
-                  <li style="background-color: {{color}}; color:{{../font_color}};" class="titlecolor"></li>
-                  <li>{{title}}</li>
-                </ul>
+                <div class="track-info">
+                  <span style="background-color: {{color}};" class="titlecolor"></span>
+                  <span class="track-name">{{title}}</li>
+                </div>
               {{/if}}
             {{/tracknames}}
           </div>
@@ -277,6 +287,36 @@
           $(this).parent().parent().find("div.social-buttons").toggle();
           var val = $(this).parent().parent().find('.speakers-inputbox').val();
           $(this).parent().parent().find('.speakers-inputbox').val(window.location.href.split('#')[0] + '#' + val.split('#').pop());
+        });
+
+        $('#clearFilter').click(function() {
+          display();
+          $('#filterInfo').hide();
+        });
+
+        $('.track-name').click(function() {
+          var trackName = $(this).text();
+          $('#filterInfo').show();
+          $('#curFilter').text(trackName);
+          $('.date-filter').each(function () {
+            var flag = 0;
+            $(this).find('.track-filter').each(function () {
+              var name = $(this).find('.text').text();
+              if(name != trackName) {
+                $(this).hide();
+                return;
+              }
+              flag = 1;
+              $(this).show();
+              $(this).children('.row').hide();
+            });
+            if(!flag) {
+              $(this).hide();
+            } else {
+              $(this).show();
+            }
+          });
+          $('html, body').animate({scrollTop: 0}, 500);
         });
 
         $('.speakers-inputbox').click(function (e) {

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -424,16 +424,6 @@ describe("Running Selenium tests on Chrome Driver", function() {
       });
     });
 
-    it('Checking subnavbar functionality', function(done) {
-      trackPage.checkAllSubnav().then(function(boolArr) {
-        trackPage.visit('http://localhost:5000/live/preview/a@a.com/FOSSASIASummit/tracks.html');
-        assert.deepEqual(boolArr, [true, true, true]);
-        done();
-      }).catch(function(err) {
-        done(err);
-      });
-    });
-
     it('Checking search functionality', function(done) {
       trackPage.commonSearchTest().then(function(boolArr) {
         assert.deepEqual(boolArr, [true, true, true, true, false, false]);


### PR DESCRIPTION
Partially Fixes the issue #1317 

**Changes**
* Makes the side track name list act as a way to filter the sessions by their type on desktops (large screens) and removed the subnavbar tracks info.
* Removed some of the old tests.

**Test Server**
http://secure-meadow-20680.herokuapp.com

**Demo Site**
https://princu7.github.io/websiteTest/tracks.html

@aayusharora @geekyd @sumedh123 @mariobehling Please review. Thanks :)