### PR TITLE
Add few tests for the filtering of sessions on tracks pages

### DIFF
--- a/src/selenium/basePage.js
+++ b/src/selenium/basePage.js
@@ -120,7 +120,9 @@ var BasePage = {
   },
 
   countOnesInArray: function(arr) {
-    return arr.reduce(function(counter, value) { return value == 1 ? counter + 1 : counter; }, 0);
+    return arr.reduce(function(counter, value) {
+      return (value === 1 || value === 'true') ? counter + 1 : counter;
+    }, 0);
   },
 
   getAllLinks: function(locator) {
@@ -281,7 +283,9 @@ var BasePage = {
       return self.find(By.id(id));
     });
 
-  return self.toggleSessionBookmark(sessionToggleArr).then(self.toggleStarredButton.bind(self)).then(self.getElemsDisplayStatus.bind(null, sessionElemArr));
+    return self.toggleSessionBookmark(sessionToggleArr).then(function() {
+      return self.driver.executeScript('window.scrollTo(0, 0)').then(self.toggleStarredButton.bind(self)).then(self.getElemsDisplayStatus.bind(null, sessionElemArr));
+    });
   }
 
 };

--- a/src/selenium/trackPage.js
+++ b/src/selenium/trackPage.js
@@ -4,22 +4,51 @@ var until = require('selenium-webdriver').until;
 
 var TrackPage = Object.create(BasePage);
 
-TrackPage.getNoOfVisibleSessionElems = function() {
+// Get number of visible tracks on the page
+TrackPage.getNumTracksVisible = function() {
   var self = this;
-  return self.findAll(By.className('room-filter')).then(self.getElemsDisplayStatus).then(function(displayArr) {
-    return self.countOnesInArray(displayArr);
+  var numPromise = new Promise(function(resolve) {
+    self.findAll(By.className('track-filter')).then(function(trackElems) {
+      var counter = 0;
+      var trackNameArr = [];
+
+      trackElems.forEach(function(trackElem) {
+        trackElem.isDisplayed().then(function(val) {
+          trackElem.findElement(By.className('text')).getText().then(function(name) {
+            if (val && trackNameArr.indexOf(name) === -1) {
+              trackNameArr.push(name);
+            }
+            counter += 1;
+            if (counter === trackElems.length) {
+              resolve(trackNameArr.length);
+            }
+          });
+        });
+      });
+    });
   });
+
+  return numPromise;
 };
 
 TrackPage.checkIsolatedBookmark = function() {
   // Sample sessions having ids of 3014 and 3015 being checked for the bookmark feature
   var self = this;
-  var bookmarkSessionsIdsArr = ['3014', '3015'];
-  var visibleCheckSessionsIdsArr = ['3014', '3015', '2918'];
+  var bookmarkSessionsIdsArr = ['3014', '3015', '2907'];
+  var visibleCheckSessionsIdsArr = ['3014', '3015', '2918', '2907'];
 
   return self.bookmarkCheck(bookmarkSessionsIdsArr, visibleCheckSessionsIdsArr);
 };
 
+// Clicks on the Open Tech Track and then returns the number of visible tracks present on the page
+TrackPage.checkIsolatedTrackFilter = function() {
+  var self = this;
+
+  return self.find(By.className('track-names')).findElements(By.className('track-name')).then(function(elems) {
+    // Clicking on the Open Tech Track
+    return elems[16].click().then(self.getNumTracksVisible.bind(self));
+  });
+};
 
 TrackPage.toggleSessionElem = function() {
   var self = this;
@@ -37,19 +66,113 @@ TrackPage.toggleSessionElem = function() {
   return promise;
 };
 
-TrackPage.searchThenStarredMode = function() {
+/* Below is the list of selected sessions which are to be tested for visiblity. Sessions having ids 3014, 3015, 3018, 2938 are
+of Open Tech Track. The former two are in bookmarked state. Session id 2907 is of Track Hardware and Making and the last session
+with id 2941 is of Database Track. */
+
+var idArr = ['3014', '3015', '3018', '2938', '2907', '2941'];
+
+// Get the visibility status of the selected sessions on enabling and disabling the track filter.
+TrackPage.filterThenSessionStatus = function(choice) {
   var self = this;
-  var idArr = ['3014', '2861', '3015'];
-  var promiseArr = idArr.map(function(elem) { return self.find(By.id(elem)); });
-  return self.search('wel').then(self.toggleStarredButton.bind(self)).then(self.getElemsDisplayStatus.bind(null, promiseArr));
+  var promiseArr = idArr.map(function(elem) {
+    return self.find(By.id(elem));
+  });
+
+  var statusPromise = new Promise(function(resolve) {
+    if (choice === 'true') {
+      // Applying track filter
+      self.find(By.className('track-names')).findElements(By.className('track-name')).then(function(elems) {
+        // Clicking on the Open Tech Track
+        elems[16].click().then(self.getElemsDisplayStatus.bind(null, promiseArr)).then(function(ans) {
+          self.driver.sleep(1000).then(function() {
+            resolve(ans);
+          });
+        });
+      });
+    } else {
+      // Removing applied track filter
+      self.find(By.id('clearFilter')).click().then(self.getElemsDisplayStatus.bind(null, promiseArr)).then(function(ans) {
+        self.driver.sleep(1000).then(function() {
+          resolve(ans);
+        });
+      });
+    }
+  });
+
+  return statusPromise;
 };
 
-TrackPage.starredModeThenSearch = function() {
+// Get the visibility status of the selected sessions after search
+TrackPage.searchThenSessionStatus = function(text) {
   var self = this;
-  var idArr = ['3014', '2861', '3015'];
-  var promiseArr = idArr.map(function(elem) { return self.find(By.id(elem)); });
-  return self.toggleStarredButton().then(self.search.bind(self, 'wel')).then(self.getElemsDisplayStatus.bind(null, promiseArr));
+  var promiseArr = idArr.map(function(elem) {
+    return self.find(By.id(elem));
+  });
+
+  return self.resetSearchBar().then(self.search.bind(self, text)).then(self.getElemsDisplayStatus.bind(null, promiseArr));
 };
 
+// Get the visibility status of the selected sessions after toggling the bookmark button
+TrackPage.starredThenSessionStatus = function() {
+  var self = this;
+  var promiseArr = idArr.map(function(elem) {
+    return self.find(By.id(elem));
+  });
+
+  return self.toggleStarredButton().then(self.getElemsDisplayStatus.bind(null, promiseArr));
+};
+
+// Takes in an array of filters, apply them sequentially and send visibility results of selected sessions on each filter
+TrackPage.filterCombination = function(filtersArr) {
+  var self = this;
+  var filterObjectFunc = {
+    'trackselect': function() {
+      return self.filterThenSessionStatus('true');
+    },
+
+    'trackunselect': function() {
+      return self.filterThenSessionStatus('false');
+    },
+
+    'search': function() {
+      return self.searchThenSessionStatus('wel');
+    },
+
+    'unsearch': function() {
+      return self.searchThenSessionStatus('');
+    },
+
+    'starred': function() {
+      return self.starredThenSessionStatus();
+    },
+
+    'unstarred': function() {
+      return self.starredThenSessionStatus();
+    }
+  };
+
+  var serialPromise = function series(arrayOfPromises) {
+    var results = [];
+
+    return arrayOfPromises.reduce(function(seriesPromise, promise) {
+      return seriesPromise.then(function() {
+        return promise.then(function(result) {
+          results.push(result);
+        });
+      });
+    }, Promise.resolve()).then(function() {
+      return results;
+    });
+  };
+
+  var filtersArrProm = [];
+
+  filtersArrProm = filtersArr.map(function(filter) {
+    return filterObjectFunc[filter]();
+  });
+
+  return serialPromise(filtersArrProm);
+};
 
 module.exports = TrackPage;

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -406,6 +406,7 @@ describe("Running Selenium tests on Chrome Driver", function() {
       });
     });
 
+
     it('Checking track name list appear near the top of page', function(done) {
       trackPage.checkTrackNamePos().then(function(boolval) {
         assert.equal(boolval, true);
@@ -464,28 +465,34 @@ describe("Running Selenium tests on Chrome Driver", function() {
     });
 
     it('Checking the bookmark toggle', function(done) {
+      trackPage.visit('http://localhost:5000/live/preview/a@a.com/FOSSASIASummit/tracks.html');
       trackPage.checkIsolatedBookmark().then(function(visArr) {
-        assert.deepEqual(visArr, [true, true, false]);
+        assert.deepEqual(visArr, [true, true, false, true]);
         done();
       }).catch(function(err) {
         done(err);
       });
     });
 
-    it('Checking the starred mode after search', function(done) {
-      trackPage.visit('http://localhost:5000/live/preview/a@a.com/FOSSASIASummit/tracks.html');
-      trackPage.searchThenStarredMode().then(function(boolArr) {
-        assert.deepEqual(boolArr, [true, false, false]);
+    it('Checking the Track Filter', function(done) {
+      trackPage.checkIsolatedTrackFilter().then(function(numTrack) {
+        assert.equal(numTrack, 1);
+        driver.sleep(1000);
         done();
       }).catch(function(err) {
         done(err);
       });
     });
 
-    it('Checking search in starred mode', function(done) {
+    it('Track filter followed by search and starred filter and reversing them', function(done) {
       trackPage.visit('http://localhost:5000/live/preview/a@a.com/FOSSASIASummit/tracks.html');
-      trackPage.starredModeThenSearch().then(function(boolArr) {
-        assert.deepEqual(boolArr, [true, false, false]);
+      trackPage.filterCombination(['trackselect', 'search', 'starred', 'unstarred', 'unsearch', 'trackunselect']).then(function(val) {
+        assert.deepEqual(val[0], [ true, true, true, true, false, false ]);
+        assert.deepEqual(val[1], [ true, false, true, false, false, false ]);
+        assert.deepEqual(val[2], [ true, false, false, false, false, false ]);
+        assert.deepEqual(val[3], val[1]);
+        assert.deepEqual(val[4], val[0]);
+        assert.deepEqual(val[5], [ true, true, true, true, true, true ]);
         done();
       }).catch(function(err) {
         done(err);


### PR DESCRIPTION
Partially fixes the issue #1317 

**Changes**: 
* Adds test cases for the filtering of sessions on tracks pages

**Note**
I have described it before. There are 3 filters and they can be applied in many orders (6 to be precise)

* Track -> Search -> Starred
* Track -> Starred -> Search
* Search -> Starred -> Track
* Search -> Track -> Starred
* Starred -> Search -> Track
* Starred -> Track -> Search

What's important to note is also that the reverse of all the filters applied should also work well. The same output which was before should display after reversing the filter too and no extra elements should be there.

eg:
Track -> Search -> Starred -> Unstarred -> Unsearch -> Untrack
Output after the 2nd and the 4th step should match
Output after the 1st and the 5th step should match

In this, I have written the test cases for the first one. Track->Search->Starred. Will write the code for the next 5 cases in the next PR.

**Video For Demonstration**
https://saucelabs.com/beta/tests/9035048aed8e4c6b9fb99cc3070597ac/watch#718
The intended test case starts around 50sec mark

@aayusharora @geekyd @sumedh123 @harshitagupta30 Please review. Thanks :)