### PR TITLE
Made ics file download work on all browsers and changed its name to t…

### DIFF
--- a/src/backend/assets/js/icsGen.js
+++ b/src/backend/assets/js/icsGen.js
@@ -123,7 +123,8 @@ var icsGen = function () {
             var calendar = [calendarStart, calendarTimezone, calendarEvents.join(SEPARATOR), calendarEnd].join(SEPARATOR);
 
             if (!dlh) {
-                window.open("data:text/calendar;charset=utf8," + encodeURIComponent(calendar));
+                var blob = new Blob([calendar], {type: "data:text/calendar;charset=utf8"});
+                saveAs(blob, filename + ext);
             } else {
                 window.location = encodeURI(dlh) + "?f=" + encodeURIComponent(filename + "." + ext) + "&t=" + encodeURIComponent(calendar);
             }

--- a/src/backend/templates/schedule.hbs
+++ b/src/backend/templates/schedule.hbs
@@ -446,7 +446,7 @@
           });
         });
 
-        cal.download('calendar', 'ics', false);
+        cal.download(eventName, '.ics', false);
        }
 
       $('.export-schedule').click(function() {


### PR DESCRIPTION
…he event name

Fixes #1434 

**Changes**:
* Makes ICS Download of schedule work on all the browsers. Earlier, it was not working on Google Chrome due to some security issue.
* The name of the downloaded ics schedule file is the same as the name of the event.

**Screenshots for the change**: 
* In Firefox
![screenshot from 2017-08-13 14-09-03](https://user-images.githubusercontent.com/8847265/29248259-548ef7ee-8031-11e7-917b-9355c775e107.png)

* In Chromium Based Browser
![screenshot from 2017-08-13 14-08-53](https://user-images.githubusercontent.com/8847265/29248262-627ed78e-8031-11e7-81b3-ca5c18aefae1.png)

**Test Server**
http://secure-meadow-20680.herokuapp.com


@aayusharora @geekyd @sumedh123 @harshitagupta30 Please review. Thanks :)
