### PR TITLE
Add Selenium tests for checking the font color of session elements on…

### DIFF
--- a/src/selenium/basePage.js
+++ b/src/selenium/basePage.js
@@ -65,6 +65,16 @@ var BasePage = {
     return Promise.all(promiseArr);
   },
 
+  getSessionElemsColor: function() {
+    var self = this;
+    var sessionElemIdArr = ['title-3014', 'title-2941'];
+    var colorPromArr = sessionElemIdArr.map(function(sessionElemId) {
+      return self.find(By.id(sessionElemId)).getCssValue('color');
+    });
+
+    return Promise.all(colorPromArr);
+  },
+
   checkDownButton: function() {
     var self = this;
 

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -395,6 +395,15 @@ describe("Running Selenium tests on Chrome Driver", function() {
       trackPage.visit('http://localhost:5000/live/preview/a@a.com/FOSSASIASummit/tracks.html');
     });
 
+    it('Test for font color of sessions', function(done) {
+      trackPage.getSessionElemsColor().then(function(colorArr) {
+        assert.deepEqual(colorArr, ['rgba(255, 255, 255, 1)', 'rgba(0, 0, 0, 1)']);
+        done();
+      }).catch(function(err) {
+        done(err);
+      });
+    });
+
     it('Check for Scrollbars', function(done) {
       var sizesArr = [[300, 600], [720, 600]];
       trackPage.getScrollbarVisibility(sizesArr).then(function(statusArr) {
@@ -587,6 +596,15 @@ describe("Running Selenium tests on Chrome Driver", function() {
       schedulePage.visit('http://localhost:5000/live/preview/a@a.com/FOSSASIASummit/schedule.html');
     });
 
+    it('Test for font color of sessions', function(done) {
+      schedulePage.getSessionElemsColor().then(function(colorArr) {
+        assert.deepEqual(colorArr, ['rgba(255, 255, 255, 1)', 'rgba(0, 0, 0, 1)']);
+        done();
+      }).catch(function(err) {
+        done(err);
+      });
+    });
+
     it('Check for Scrollbars', function(done) {
       var sizesArr = [[300, 600], [720, 600]];
       schedulePage.getScrollbarVisibility(sizesArr).then(function(statusArr) {
@@ -737,6 +755,15 @@ describe("Running Selenium tests on Chrome Driver", function() {
     before(function() {
       roomPage.init(driver);
       roomPage.visit('http://localhost:5000/live/preview/a@a.com/FOSSASIASummit/rooms.html');
+    });
+
+    it('Test for font color of sessions', function(done) {
+      roomPage.getSessionElemsColor().then(function(colorArr) {
+        assert.deepEqual(colorArr, ['rgba(255, 255, 255, 1)', 'rgba(0, 0, 0, 1)']);
+        done();
+      }).catch(function(err) {
+        done(err);
+      });
     });
 
     it('Check for Scrollbars', function(done) {


### PR DESCRIPTION
… different pages

Fixes #1311, #1217 completely

Changes:
* Adds selenium tests for checking the font color of session elements on different pages (tracks, rooms and schedule pages). Takes two sessions. One of their font-color should be white and the other font-color should be black. Checks the color equality on different pages.

