### PR TITLE
Send correct event folder link and a message to inform user in the mail when the cloud upload fails

### DIFF
--- a/src/backend/generator.js
+++ b/src/backend/generator.js
@@ -524,12 +524,12 @@ exports.createDistDir = function(req, socket, callback) {
         }, 30000);
       }
 
-      mailer.uploadAndsendMail(req.body.email, eventName, socket, (url) => {
-        if(url)
+      mailer.uploadAndsendMail(req.body.email, eventName, socket, (obj) => {
+        if(obj.mail)
           logger.addLog('Success', 'Mail sent succesfully', socket);
         else
           logger.addLog('Error', 'Error sending mail', socket);
-        callback(appFolder, url);
+        callback(appFolder, obj.url);
         done(null, 'write');
       });
 


### PR DESCRIPTION

Fixes #1452 

**Changes**:
* Send correct event folder link and a message to inform the user in the mail when the cloud upload fails. The user will receive the email containing the download link of the event folder on the Heroku itself along with the message that the zip will be purged within few hours and to download it immediately.

Screenshots for the change: 
![screenshot from 2017-08-22 23-46-44](https://user-images.githubusercontent.com/8847265/29580713-98a2f128-8794-11e7-9612-5b859ff476d7.png)

**Test Server**
http://peaceful-meadow-19050.herokuapp.com

@aayusharora @geekyd @sumedh123 @harshitagupta30 Please review. Thanks :)

