### PR TITLE
Added error log when unable to download jsons due to connectivity problem

### DIFF
--- a/src/backend/dist.js
+++ b/src/backend/dist.js
@@ -78,7 +78,11 @@ const downloadJson = function(appPath, endpoint, jsonFile, cb) {
   try {
     console.log('Downloading ' + endpoint + '/' + jsonFile);
     request
-      .get(endpoint + '/' + jsonFile)
+      .get({url:endpoint + '/' + jsonFile,timeout:30000})
+      .on('error', function (error) {
+        cb(new Error(error.code));
+        console.log('Could not connect to server');
+      })
       .on('response', function(response) {
         if (response.statusCode != 200) {
           cb(new Error('Response = ' + response.statusCode + 'received'));


### PR DESCRIPTION
First step for #1455 [Error is displayed if jsons fail to download due to internet connectivity problem] 

Changes: Added error event function on request url.

Screenshots for the change
![screenshot from 2017-08-26 21-26-54](https://user-images.githubusercontent.com/21157929/29743662-02e73f68-8ab4-11e7-9810-0be247680dfb.png)

