### PR TITLE
Fix overflowing text

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -1836,6 +1836,7 @@ a.skip:hover {
 
 .session-name {
   overflow: hidden;
+  white-space: nowrap;
   text-overflow: ellipsis;
 }
 


### PR DESCRIPTION
Fixes #1470 
Fixed overflowing text in calendar view of schedule page.
Changes: added ```white-space: nowrap;```  for ```text-overflow: ellipsis;``` to work.

Screenshots for the change:

![image](https://user-images.githubusercontent.com/20224346/31067425-6a9bfe00-a742-11e7-86ea-91c6417b9708.png)


Please review and feedback whether this is the required change or not.Thanks.


