### PR TITLE
Fix misspelt variable name in /src/backend/generator.js

### DIFF
--- a/src/backend/generator.js
+++ b/src/backend/generator.js
@@ -462,7 +462,7 @@ exports.createDistDir = function(req, socket, callback) {
 
       fs.move(eventFolderSource + appFolder, eventFolderSource + req.body.email + '/' + eventName, (moveerr) => {
         if (moveerr !== null) {
-          logger.addLog('Error', 'Error in moving files to the event folders', socket, moverr);
+          logger.addLog('Error', 'Error in moving files to the event folders', socket, moveerr);
           console.log(moveerr);
           if (emit) socket.emit('live.error', {status: "Error in moving files to the event directory" });
         }


### PR DESCRIPTION


Changes: changed misspelt ```moverr``` to ```moveerr``` .

This prevented me from  generating any webpage through my local machine installation.


