### PR TITLE
index.html: Version link improved

### DIFF
--- a/src/www/index.html
+++ b/src/www/index.html
@@ -285,8 +285,7 @@
     </form>
   </div>
   <div id="deployment">
-    <span> <strong>Version: </strong></span>
-    <span> <a id="deploy-link"> </a> </span>
+    <span> <a id="deploy-link">Version</a> </span>
   </div>
 </body>
 </html>

--- a/src/www/js/form.js
+++ b/src/www/js/form.js
@@ -258,7 +258,6 @@ $(document).ready(function () {
       var versionLink = 'https://github.com/fossasia/open-event-webapp/tree/' + version;
       var deployLink = $('#deploy-link');
       deployLink.attr('href', versionLink);
-      deployLink.html(version);
     }});
   }
 


### PR DESCRIPTION
Instead of having the commit id being displayed in entirety,
only version link is provided.

Fixes https://github.com/fossasia/open-event-webapp/issues/1509

Changes: Instead of displaying the entire id in its entirety, it just provides link to go to latest version.

Screenshots for the change: 
![screen shot 2017-10-19 at 6 12 44 pm](https://user-images.githubusercontent.com/27735438/31771281-237c7b84-b4f9-11e7-8e1e-aecfc2219a23.png)
