### PR TITLE
Fixes #1595: Fixes main text in overviewSite on mobile UI

### DIFF
--- a/src/backend/overviewSite/index.html
+++ b/src/backend/overviewSite/index.html
@@ -67,8 +67,11 @@
         }
 
         .banner .container {
-            margin-top: -350px;
             color: white;
+            position: absolute;
+            text-align: center;
+            width: 100%;
+            margin-top: 10%;
         }
 
         .banner .container h1 {
@@ -138,13 +141,13 @@
 </nav>
 
 <div class="banner">
-    <div class="tint"></div>
     <div class="container text-center">
         <h1>Open Event Web Apps</h1>
         <p>The <a href="https://webgen.eventyay.com"> Open Event Web App Generator </a>uses the <a
                 href="https://github.com/fossasia/open-event"> Open Event format </a> to generate static websites of
             events. Feast your eyes on our beautiful example events.</p>
     </div>
+    <div class="tint"></div>
 </div>
 
 <div class="container-fluid bg-3">


### PR DESCRIPTION
Fixes #1595

Changes:
Fixes main text in the overviewSite on the mobile UI of open event
webapp. The text was overflowing in mobile versions. Fixes the bug of main
text overflow.

Screenshots for the change: 
Before this PR:
![screenshot_20180107_184528](https://user-images.githubusercontent.com/8947010/34649874-374b4c58-f3dd-11e7-8b6b-2bb2cd43138b.png)

After this PR:
![screenshot_20180107_185843](https://user-images.githubusercontent.com/8947010/34649871-2a5084b4-f3dd-11e7-858b-c6874d9dc304.png)
![screenshot_20180107_185907](https://user-images.githubusercontent.com/8947010/34649872-2a97b4a6-f3dd-11e7-959a-26f60c90bd08.png)

