### PR TITLE
Removed errors while speakers image modulation using sharp

### DIFF
--- a/src/backend/dist.js
+++ b/src/backend/dist.js
@@ -241,7 +241,8 @@ var resizeSponsors = function(dir, socket, done) {
 };
 
 var resizeSpeakers = function(dir, socket, done) {
-  fs.readdir(dir + '/speakers/', function(err, list){
+  fs.readdir(dir + '/speakers/', function(err, array){
+    var list = array.splice(array.splice( array.indexOf('thumbnails'), 1 ));
     if(err) {
       logger.addLog('Info', 'No sponsors images found', socket, err);
     }


### PR DESCRIPTION
Fixes #1599 

Changes: `fs.readdir` was also reading thumbnails folder as the image to be resized.Removing thumbnails directory from the modulation list removed the console errors as it is a directory not an image.


  