### PR TITLE
Pop-box is displayed properly when clicking session-name thrice

### DIFF
--- a/src/backend/assets/js/popover.js
+++ b/src/backend/assets/js/popover.js
@@ -63,6 +63,7 @@ $(document).ready(function () {
       if($(this).is(openedPop)) {
         resetPage();
         $(this).find('.pop-box').toggleClass('hide');
+        openedPop=null;
       } else {
         resetPage();
         openedPop = this;


### PR DESCRIPTION
#### Changes proposed in this pull request:
Earlier when session was clicked for the first time the following was executed:-
  1.) resetPage();
 2.) openedPop = this;
 addPopbox(this);

 When the session was clicked for the second time the following statements were executed  :-  
  1.) resetPage();
  2.) $(this).find('.pop-box').toggleClass('hide');
  But openedPop is still equal to this.
  I have set openedPop to null when we click session for second time . 

 Link of open-event-webapp with resolved issue :- https://frozen-oasis-52185.herokuapp.com/

Fixes #1692 
