### PR TITLE
Pop-box and scroll bar are working properly when leaving the schedule page

### DIFF
--- a/src/backend/assets/js/popover.js
+++ b/src/backend/assets/js/popover.js
@@ -54,6 +54,7 @@ $(document).ready(function () {
     });
     $(document).hover(function(event){
       popbox.addClass('hide');
+      resetPage();
       hidePopbox();
     });
   }

--- a/src/backend/assets/js/popover.js
+++ b/src/backend/assets/js/popover.js
@@ -55,6 +55,7 @@ $(document).ready(function () {
     $(document).hover(function(event){
       popbox.addClass('hide');
       resetPage();
+      openedPop=null;
       hidePopbox();
     });
   }


### PR DESCRIPTION
#### Changes proposed in this pull request:
When we click session-name in schedule page the following gets executed:-
1.)pop-box hide
2.)resetPage() is called
3.)openedPop=null;
When we leave the screen and come back the following get executed:-
1)pop-box hide
resetPage() is not being called and openedPage is not set to null whick cause the error.
Now when we leave the page resetPage() is being called and openedPage is set to  null.

link to website with resolved issue:- https://stark-everglades-31879.herokuapp.com/

Fixes #1700 
