### PR TITLE
Rectify Overlap in search speaker for small screen view

### DIFF
--- a/src/backend/templates/speakers.hbs
+++ b/src/backend/templates/speakers.hbs
@@ -41,10 +41,10 @@
   <style>
   .search-filter>label>.fa {
     position: absolute;
-    padding-top: 20px;
+    padding-top: 25px;
     padding-left: 67px;
   }
-  @media only screen and (max-width: 450px) {
+  @media only screen and (max-width: 600px) {
          .search-filter>label>.fa {
              position: absolute;
              padding-top: 25px;


### PR DESCRIPTION
#### Short description of what this resolves:
Rectifies the overlap of search icon with the search input field, while searching for a  speaker in small screen view.

#### Changes proposed in this pull request:

1. Align from left
- remove this line - `@media only screen and (max-width: 450px) {`
- add this line  `@media only screen and (max-width: 600px) {`
2. Align from top (center it)
- remove this line -    `padding-top: 20px;`
- add this line -  `padding-top: 25px;`

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1776 
