### PR TITLE
Move personal links below to speaker name

### DIFF
--- a/src/backend/templates/rooms.hbs
+++ b/src/backend/templates/rooms.hbs
@@ -194,12 +194,7 @@
                                         {{position}} {{organisation}}
                                       </p>
                                     {{/if}}
-                                    {{#if biography}}
-                                      <div class="session-speakers-more">
-                                        {{{biography}}}
-                                      </div>
-                                    {{/if}}
-                                    <div class="blacktext session-speaker-social">
+                                    <div class="blacktext session-speaker-social margin-down-10">
                                       <div class="session-speakers-more">
                                         {{#if website}}
                                           <a class="blacktext social speaker-social" href="{{{website}}}"}>
@@ -221,6 +216,15 @@
                                             <i class="fa fa-linkedin"></i> LinkedIn
                                           </a>&nbsp;
                                         {{/if}}
+                                      </div>
+                                    </div>
+                                    {{#if biography}}
+                                      <div class="session-speakers-more">
+                                        {{{biography}}}
+                                      </div>
+                                    {{/if}}
+                                    <div class="blacktext session-speaker-social">
+                                      <div class="session-speakers-more">
                                         <a class="session-lin blacktext social speaker-social clickable-link">
                                           <i class="fa fa-share"></i> Share
                                         </a>

--- a/src/backend/templates/schedule.hbs
+++ b/src/backend/templates/schedule.hbs
@@ -172,12 +172,7 @@
                             {{position}} {{organisation}}
                           </div>
                           {{/if}}
-                          {{#if biography}}
-                            <div class="session-speakers-more margin-down-10">
-                              {{{biography}}}
-                            </div>
-                          {{/if}}
-                          <div class="blacktext session-speaker-social">
+                          <div class="blacktext session-speaker-social margin-down-10">
                             <div class="session-speakers-more">
                               {{#if website}}
                               <a class="blacktext social speaker-social" href="{{{website}}}"}>
@@ -199,6 +194,15 @@
                                 <i class="fa fa-linkedin"></i> LinkedIn
                               </a>&nbsp;
                               {{/if}}
+                            </div>
+                          </div>
+                          {{#if biography}}
+                            <div class="session-speakers-more margin-down-10">
+                              {{{biography}}}
+                            </div>
+                          {{/if}}
+                          <div class="blacktext session-speaker-social">
+                            <div class="session-speakers-more">
                               <a class="session-lin social speaker-social clickable-link">
                                 <i class="fa fa-share"></i> Share
                               </a>&nbsp;

--- a/src/backend/templates/session.hbs
+++ b/src/backend/templates/session.hbs
@@ -88,12 +88,7 @@
                   {{#if organisation}}
                     <p class="session-speakers-more">{{position}} {{organisation}}</p>
                   {{/if}}
-                  {{#if biography}}
-                    <div class="session-speakers-more">
-                      {{{biography}}}
-                    </div>
-                  {{/if}}
-                  <div class="blacktext session-speaker-social">
+                  <div class="blacktext session-speaker-social margin-down-10">
                     <div class="session-speakers-more">
                       {{#if web}}
                         <a class="blacktext social speaker-social" href="{{{web}}}"><i
@@ -111,6 +106,15 @@
                         <a class="blacktext social speaker-social" href="{{{linkedin}}}"><i
                             class="fa fa-linkedin"></i> LinkedIn</a>&nbsp;
                       {{/if}}
+                    </div>
+                  </div>
+                  {{#if biography}}
+                    <div class="session-speakers-more">
+                      {{{biography}}}
+                    </div>
+                  {{/if}}
+                  <div class="blacktext session-speaker-social">
+                    <div class="session-speakers-more">
                       <a class="session-lin social speaker-social clickable-link">
                         <i class="fa fa-share"></i> Share
                       </a>&nbsp;

--- a/src/backend/templates/tracks.hbs
+++ b/src/backend/templates/tracks.hbs
@@ -192,12 +192,7 @@
                                   {{#if organisation}}
                                     <p class="session-speakers-more">{{position}} {{organisation}}</p>
                                   {{/if}}
-                                  {{#if biography}}
-                                    <div class="session-speakers-more">
-                                      {{{biography}}}
-                                    </div>
-                                  {{/if}}
-                                  <div class="blacktext session-speaker-social">
+                                  <div class="blacktext session-speaker-social margin-down-10">
                                     <div class="session-speakers-more">
                                       {{#if web}}
                                         <a class="blacktext social speaker-social" href="{{{web}}}"><i
@@ -215,6 +210,15 @@
                                         <a class="blacktext social speaker-social" href="{{{linkedin}}}"><i
                                             class="fa fa-linkedin"></i> LinkedIn</a>&nbsp;
                                       {{/if}}
+                                    </div>
+                                  </div>
+                                  {{#if biography}}
+                                    <div class="session-speakers-more">
+                                      {{{biography}}}
+                                    </div>
+                                  {{/if}}
+                                  <div class="blacktext session-speaker-social">
+                                    <div class="session-speakers-more">
                                       <a class="session-lin social speaker-social clickable-link">
                                         <i class="fa fa-share"></i> Share
                                       </a>&nbsp;


### PR DESCRIPTION
#### Short description of what this resolves:
Move speaker's personal links below to his name for both Single and Expandable modes.

Fixes #1808.

Deployment link (for Expandable mode): https://adityahirapara.github.io/eventSiteWebApp/

Deployment link (for Single mode): https://adityahirapara.github.io/eventSiteWebAppTwo/
