### PR TITLE
hide horizontal scroll when less columns(#1472)

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -1810,7 +1810,7 @@ a.skip:hover {
 .rooms {
   overflow: hidden;
   overflow-x : auto;
-  width: calc(100% - 80px);
+  width: calc(100% - 48px);
   display: inline-block;
   white-space: nowrap;
 }
@@ -1820,6 +1820,7 @@ a.skip:hover {
   white-space: initial;
   display: inline-block;
   position: relative;
+  min-width: 160px;
 }
 
 .room-filter {

--- a/src/backend/fold_v1.js
+++ b/src/backend/fold_v1.js
@@ -113,10 +113,10 @@ function createTimeLine(startTime, endTime) {
 
 function checkWidth(columns) {
   if(columns * columnWidth > calendarWidth) {
-    return columnWidth;
+    return columnWidth + 'px';
   } else {
-    let whiteSpace = (calendarWidth - columns * columnWidth) / columns;
-    return columnWidth + whiteSpace;
+    let percentageWidth = 100 / columns;
+    return percentageWidth + '%';
   }
 }
 

--- a/src/backend/fold_v2.js
+++ b/src/backend/fold_v2.js
@@ -115,10 +115,10 @@ function createTimeLine(startTime, endTime) {
 
 function checkWidth(columns) {
   if(columns * columnWidth > calendarWidth) {
-    return columnWidth;
+    return columnWidth + 'px';
   } else {
-    let whiteSpace = (calendarWidth - columns * columnWidth) / columns;
-    return columnWidth + whiteSpace;
+    let percentageWidth = 100 / columns;
+    return percentageWidth + '%';
   }
 }
 

--- a/src/backend/templates/schedule.hbs
+++ b/src/backend/templates/schedule.hbs
@@ -265,8 +265,8 @@
                 </div>
                 <div class="rooms" style="height: {{{height}}}px;background-image: url('images/timeline.png');background-repeat: repeat;">
                   {{#venue}}
-                  <div class="room">
-                    <div class="room-header" style="width: {{{../width}}}px; height: {{{../timeToPixel}}}px;">
+                  <div class="room" style="width: {{{../width}}};">
+                    <div class="room-header" style="height: {{{../timeToPixel}}}px;">
                       {{#if venue }}
                         <span>{{venue}}</span>
                       {{/if}}


### PR DESCRIPTION
#### Short description of what this resolves:
In calendar view of schedule page, hide horizontal scroll when there are few columns.

Fixes #1472.

Deployment link: (Heroku) https://openeventwebapp.herokuapp.com/
                            (gh-pages) https://adityahirapara.github.io/eventSiteWebApp/index.html
