### PR TITLE
Find download button by icon, instead of by position, when testing

### DIFF
--- a/src/selenium/schedulePage.js
+++ b/src/selenium/schedulePage.js
@@ -58,21 +58,27 @@ SchedulePage.toggleMode = function() {
 
 SchedulePage.getDownloadDropdown = function() {
   var self = this;
-  var downloadButtonId = 'dropdown-toggle';
   var promiseArr = [];
 
-  var promise = new Promise(function(resolve) {
-    self.find(By.className(downloadButtonId)).then(self.click).then(self.driver.sleep(1000)).then(function() {
-      promiseArr.push(self.find(By.className('download-dropdown')).isDisplayed());
-    }).then(function() {
-      self.find(By.className(downloadButtonId)).then(self.click).then(self.driver.sleep(1000)).then(function() {
-        promiseArr.push(self.find(By.className('download-dropdown')).isDisplayed());
-        resolve(Promise.all(promiseArr));
-      });
+  var clickDropdownButton = function() {
+    return self.find(By.css('.filter.dropdown .fa-download')).then(function(icon) {
+      return icon.findElement(By.xpath('..'));
+    }).then(function(button) {
+      return button.click().then(self.driver.sleep(1000));
     });
-  });
+  };
 
-  return promise;
+  return Promise.resolve().then(function() {
+    return clickDropdownButton();
+  }).then(function() {
+    promiseArr.push(self.find(By.className('download-dropdown')).isDisplayed());
+  }).then(function() {
+    return clickDropdownButton();
+  }).then(function() {
+    promiseArr.push(self.find(By.className('download-dropdown')).isDisplayed());
+  }).then(function() {
+    return Promise.all(promiseArr);
+  });
 };
 
 SchedulePage.checkFilterDirectLink = function() {


### PR DESCRIPTION
Currently the test that checks whether the download dropdown menu is working finds the button to click by searching for the first `.dropdown-toggle` element on the page.

This PR improves the search. Since we can't find the actual button directly by a class, we search for the `.fa-download` icon inside it, and then step up from there to the parent button.

`icon.findElement(By.xpath('..'))` is what I used to step up to the parent element.

This change is needed for #1860 because that re-arranges the filter buttons, causing the test to fail in its current form. Assists towards #1781