### PR TITLE
Fixes overflowing logs and word break on generator page

### DIFF
--- a/src/www/css/main.css
+++ b/src/www/css/main.css
@@ -41,7 +41,9 @@ center{
 pre#buildLog{
 	max-height: 400px;
 	font-size: 12px;
+    overflow-y: auto;
 	text-align: left;
+    word-break: unset;
 }
 
 #btnLive, #btnDownload, #deploy {


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.

#### Short description of what this resolves:
Fixes overflowing log division on generator page.

Fixes #1896 
Preview link: https://openeveweb.herokuapp.com/
Screenshot:
![screenshot-2018-5-30 webapp generator](https://user-images.githubusercontent.com/21157929/40707758-41f2d386-640f-11e8-8e53-f5d70d67e184.png)

