### PR TITLE
Makes only speaker's entity clickable in expandable session style

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -2220,3 +2220,7 @@ a.skip:hover {
 .video {
   color: $black;
 }
+
+.desc-speaker-name {
+  display: block;
+}

--- a/src/backend/templates/rooms.hbs
+++ b/src/backend/templates/rooms.hbs
@@ -187,18 +187,19 @@
                                   aria-expanded="false"
                                   aria-controls="desc-{{session_id}}">
                                   {{#speakers_list}}
-                                    <a href="speakers.html#{{nameIdSlug}}">
-                                      <div class="session-speakers-less">
-                                        <p class="session-speakers">
+                                    <div class="session-speakers-less">
+                                      <p class="session-speakers">
+                                        <a href="speakers.html#{{nameIdSlug}}">
                                           {{#if photo}}
-                                            <img onError="this.onerror=null;this.src='images/avatar.png';" data-original="{{thumb}}" class="lazy card-img-top speaker-image-large"/>
+                                            <img onError="this.onerror=null;this.src='images/avatar.png';" data-original="{{thumb}}" class="lazy card-img-top speaker-image-large margin-down-10"/>
                                           {{else}}
-                                            <img class="card-img-top speaker-image-large" src="images/avatar.png"/>
+                                            <img class="card-img-top speaker-image-large margin-down-10" src="images/avatar.png"/>
                                           {{/if}}
-                                        </p>
-                                        <span class="graytext">{{name}}</span>
-                                      </div>
-                                    </a>
+                                          <span class="graytext desc-speaker-name">{{name}}</span>
+                                        </a>
+                                      </p>
+                                    </div>
+
                                     {{#if organisation}}
                                       <p class="session-speakers-more">
                                         {{position}} {{organisation}}

--- a/src/backend/templates/schedule.hbs
+++ b/src/backend/templates/schedule.hbs
@@ -167,16 +167,16 @@
                           aria-expanded="false"
                           aria-controls="desc-{{session_id}}">
                           {{#each speakers_list}}
-                          <a href="speakers.html#{{nameIdSlug}}">
-                              <div class="margin-down-10">
-                              {{#if photo}}
-                                <img onError="this.onerror=null;this.src='images/avatar.png';" data-original="{{{thumb}}}" class="card-img-top speaker-image-large lazy" width="10" height="10"/>
-                              {{else}}
-                                <img class="card-img-top speaker-image-large" src="images/avatar.png"/>
-                              {{/if}}
-                              </div>
-                              <span class="margin-down-10">{{name}}</span>
-                          </a>
+                            <div class="margin-down-10">
+                              <a href="speakers.html#{{nameIdSlug}}">
+                                {{#if photo}}
+                                  <img onError="this.onerror=null;this.src='images/avatar.png';" data-original="{{{thumb}}}" class="card-img-top speaker-image-large lazy margin-down-10" width="10" height="10"/>
+                                {{else}}
+                                  <img class="card-img-top speaker-image-large margin-down-10" src="images/avatar.png"/>
+                                {{/if}}
+                                <span class="margin-down-10 desc-speaker-name">{{name}}</span>
+                              </a>
+                            </div>
                           {{#if organisation}}
                           <div class="session-speakers-more margin-down-10">
                             {{position}} {{organisation}}

--- a/src/backend/templates/tracks.hbs
+++ b/src/backend/templates/tracks.hbs
@@ -185,19 +185,19 @@
                               <div class="session-speakers-list" aria-expanded="false"
                                 aria-controls="desc-{{session_id}}">
                                 {{#speakers_list}}
-                                  <a href="speakers.html#{{nameIdSlug}}">
-                                    <div class="session-speakers-less">
-                                      <p class="session-speakers">
+                                  <div class="session-speakers-less">
+                                    <p class="session-speakers">
+                                      <a href="speakers.html#{{nameIdSlug}}">
                                         {{#if photo}}
                                           <img onError="this.onerror=null;this.src='./images/avatar.png';"
-                                          data-original="{{thumb}}" class="lazy card-img-top speaker-image-large"/>
+                                          data-original="{{thumb}}" class="lazy card-img-top speaker-image-large margin-down-10"/>
                                         {{else}}
-                                          <img class="card-img-top speaker-image-large" src="./images/avatar.png"/>
+                                          <img class="card-img-top speaker-image-large margin-down-10" src="./images/avatar.png"/>
                                         {{/if}}
-                                      </p>
-                                      <span class="graytext">{{name}}</span>
-                                    </div>
-                                  </a>
+                                        <span class="graytext desc-speaker-name">{{name}}</span>
+                                      </a>
+                                    </p>
+                                  </div>
                                   {{#if organisation}}
                                     <p class="session-speakers-more">{{position}} {{organisation}}</p>
                                   {{/if}}


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.

#### Short description of what this resolves:
Makes only speaker's entity(Image and name) clickable instead of whole division.

Fixes #1919 
Preview Link: https://agbilotia1998.github.io/OWA-expandable