### PR TITLE
Shows audio and slides only if data is in correct format

### DIFF
--- a/src/backend/generator.js
+++ b/src/backend/generator.js
@@ -70,7 +70,7 @@ handlebars.registerHelper('ifvalue', function (conditional, options) {
 });
 
 handlebars.registerHelper('ifcontains', function (string, substring, options) {
-    if (string.indexOf(substring) !== -1){
+    if (string && string.indexOf(substring) !== -1){
         return options.fn(this);
     }
     else{

--- a/src/backend/templates/rooms.hbs
+++ b/src/backend/templates/rooms.hbs
@@ -138,13 +138,19 @@
                                       <i id="v{{session_id}}" class="fa fa-circle video-circle fa-stack-2x"></i>
                                     </span>
                                   {{/if}}
-                                  {{#if audio}}
-                                    <i class="fa fa-music" aria-hidden="true"></i>
-                                  {{/if}}
+                                    {{#ifcontains audio "mp3"}}
+                                      <i class="fa fa-music" aria-hidden="true"></i>
+                                    {{/ifcontains}}
+                                    {{#ifcontains audio "aac"}}
+                                      <i class="fa fa-music" aria-hidden="true"></i>
+                                    {{/ifcontains}}
 
-                                  {{#if slides}}
-                                    <i class="fa fa-file-powerpoint-o" aria-hidden="true"></i>
-                                  {{/if}}
+                                    {{#ifcontains slides "ppt"}}
+                                      <i class="fa fa-file-powerpoint-o" aria-hidden="true"></i>
+                                    {{/ifcontains}}
+                                    {{#ifcontains slides "pdf"}}
+                                      <i class="fa fa-file-powerpoint-o" aria-hidden="true"></i>
+                                    {{/ifcontains}}
                                 </div>
                                 <div id="desc2-{{session_id}}" class="collapse in"
                                   style="background-color:{{{color}}}; color: {{{font_color}}};">
@@ -181,11 +187,16 @@
                               </div>
                               <div id="desc-{{session_id}}" class="collapse">
                                 {{{description}}}
-                                {{#if audio}}
-                                  <audio controls="" preload="none" id= "audio-block">
+                                {{#ifcontains audio "mp3"}}
+                                  <audio controls="" preload="none" id="audio-block">
                                     <source src="{{ audio }}">
                                   </audio>
-                                {{/if}}
+                                {{/ifcontains}}
+                                {{#ifcontains audio "aac"}}
+                                  <audio controls="" preload="none" id="audio-block">
+                                    <source src="{{ audio }}">
+                                  </audio>
+                                {{/ifcontains}}
                                 <hr class="clear-both">
                                 <div id="speaker-{{session_id}}" class="session-speakers-list"
                                   aria-expanded="false"

--- a/src/backend/templates/schedule.hbs
+++ b/src/backend/templates/schedule.hbs
@@ -148,21 +148,32 @@
                               <i id="v{{session_id}}" class="fa fa-circle video-circle fa-stack-2x"></i>
                             </span>
                           {{/if}}
-                          {{#if audio}}
+                          {{#ifcontains audio "mp3"}}
                             <i class="fa fa-music" aria-hidden="true"></i>
-                          {{/if}}
-                          {{#if slides}}
+                          {{/ifcontains}}
+                          {{#ifcontains audio "aac"}}
+                            <i class="fa fa-music" aria-hidden="true"></i>
+                          {{/ifcontains}}
+                          {{#ifcontains slides "ppt"}}
                             <i class="fa fa-file-powerpoint-o" aria-hidden="true"></i>
-                          {{/if}}
+                          {{/ifcontains}}
+                          {{#ifcontains slides "pdf"}}
+                            <i class="fa fa-file-powerpoint-o" aria-hidden="true"></i>
+                          {{/ifcontains}}
                         </div>
                       </h4>
                       <div id="desc-{{session_id}}" class="collapse">
                         {{{description}}}
-                        {{#if audio}}
+                        {{#ifcontains audio "mp3"}}
                           <audio controls="" preload="none" id="audio-block">
                             <source src="{{ audio }}">
                           </audio>
-                        {{/if}}
+                        {{/ifcontains}}
+                        {{#ifcontains audio "aac"}}
+                          <audio controls="" preload="none" id="audio-block">
+                            <source src="{{ audio }}">
+                          </audio>
+                        {{/ifcontains}}
                         {{#ifvalue description notequals=""}}
                           <hr class="clear-both">
                         {{/ifvalue}}

--- a/src/backend/templates/session.hbs
+++ b/src/backend/templates/session.hbs
@@ -62,11 +62,16 @@
             <div>
               <div>
                 {{{description}}}
-                {{#if audio}}
-                  <audio controls="" id="audio-block" preload="none">
+                {{#ifcontains audio "mp3"}}
+                  <audio controls="" preload="none" id="audio-block">
                     <source src="{{ audio }}">
                   </audio>
-                {{/if}}
+                {{/ifcontains}}
+                {{#ifcontains audio "aac"}}
+                  <audio controls="" preload="none" id="audio-block">
+                    <source src="{{ audio }}">
+                  </audio>
+                {{/ifcontains}}
                 <hr class="clear-both">
                 {{#ifcontains slides "ppt"}}
                   <iframe id = "slide" class = "iframe col-xs-12 col-sm-12 col-md-12" frameborder="0" src="https://view.officeapps.live.com/op/embed.aspx?src={{slides}}">

--- a/src/backend/templates/tracks.hbs
+++ b/src/backend/templates/tracks.hbs
@@ -142,12 +142,18 @@
                                     <i id="v{{session_id}}" class="fa fa-circle video-circle fa-stack-2x"></i>
                                   </span>
                                 {{/if}}
-                                {{#if audio}}
+                                {{#ifcontains audio "mp3"}}
                                   <i class="fa fa-music" aria-hidden="true"></i>
-                                {{/if}}
-                                {{#if slides}}
+                                {{/ifcontains}}
+                                {{#ifcontains audio "aac"}}
+                                  <i class="fa fa-music" aria-hidden="true"></i>
+                                {{/ifcontains}}
+                                {{#ifcontains slides "ppt"}}
                                   <i class="fa fa-file-powerpoint-o" aria-hidden="true"></i>
-                                {{/if}}
+                                {{/ifcontains}}
+                                {{#ifcontains slides "pdf"}}
+                                  <i class="fa fa-file-powerpoint-o" aria-hidden="true"></i>
+                                {{/ifcontains}}
                               </div>
                               <div id="desc2-{{session_id}}" class="collapse in"
                                 style="background-color: {{../color}}; color: {{../font_color}};">
@@ -179,11 +185,16 @@
                             </div>
                             <div id="desc-{{session_id}}" class="collapse">
                               {{{description}}}
-                              {{#if audio}}
-                                <audio controls="" id="audio-block" preload="none">
+                              {{#ifcontains audio "mp3"}}
+                                <audio controls="" preload="none" id="audio-block">
                                   <source src="{{ audio }}">
                                 </audio>
-                              {{/if}}
+                              {{/ifcontains}}
+                              {{#ifcontains audio "aac"}}
+                                <audio controls="" preload="none" id="audio-block">
+                                  <source src="{{ audio }}">
+                                </audio>
+                              {{/ifcontains}}
                               <hr class="clear-both">
                               <div id="speaker-{{session_id}}" class="session-speakers-list" aria-expanded="false"
                                 aria-controls="desc-{{session_id}}">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.

#### Short description of what this resolves:
Shows audio and slides only if data is in the correct format.

#### Changes proposed in this pull request:

- Adds check statements for data format.

Fixes #1929 
Server Link: https://opev-gen.herokuapp.com/
Preview Link: https://agbilotia1998.github.io/OWA/tracks.html#4323