### PR TITLE
Use latest templates

### DIFF
--- a/src/backend/generator.js
+++ b/src/backend/generator.js
@@ -19,6 +19,16 @@ const ftpDeployer = require('./ftpdeploy');
 const app = require('../app');
 let fold;
 
+function registerPartial(name) {
+  const partial = handlebars.compile(fs.readFileSync(__dirname + '/templates/partials/' + name + '.hbs').toString('utf-8'));
+
+  handlebars.registerPartial(name, partial);
+}
+
+function compileTemplate(name) {
+  return handlebars.compile(fs.readFileSync(__dirname + '/templates/' + name + '.hbs').toString('utf-8'));
+}
+
 if (!String.linkify) {
   String.prototype.linkify = function() {
     const urlPattern = /\b(?:https?|ftp):\/\/[a-z0-9-+&@#\/%?=~_|!:,.;]*[a-z0-9-+&@#\/%=~_|]/gim;
@@ -421,29 +431,21 @@ exports.createDistDir = function(req, socket, callback) {
 
         function templateGenerate() {
           try {
-            const navbar = handlebars.compile(fs.readFileSync(__dirname + '/templates/partials/navbar.hbs').toString('utf-8'));
-            const footer = handlebars.compile(fs.readFileSync(__dirname + '/templates/partials/footer.hbs').toString('utf-8'));
-            const scroll = handlebars.compile(fs.readFileSync(__dirname + '/templates/partials/scroll.hbs').toString('utf-8'));
-            const social = handlebars.compile(fs.readFileSync(__dirname + '/templates/partials/social.hbs').toString('utf-8'));
-            const tracklist = handlebars.compile(fs.readFileSync(__dirname + '/templates/partials/tracklist.hbs').toString('utf-8'));
-            const roomlist = handlebars.compile(fs.readFileSync(__dirname + '/templates/partials/roomlist.hbs').toString('utf-8'));
-            const googleanalytics = handlebars.compile(fs.readFileSync(__dirname + '/templates/partials/googleanalytics.hbs').toString('utf-8'));
+            registerPartial('navbar');
+            registerPartial('footer');
+            registerPartial('scroll');
+            registerPartial('social');
+            registerPartial('tracklist');
+            registerPartial('roomlist');
+            registerPartial('googleanalytics');
 
-            handlebars.registerPartial('navbar', navbar);
-            handlebars.registerPartial('footer', footer);
-            handlebars.registerPartial('scroll', scroll);
-            handlebars.registerPartial('social', social);
-            handlebars.registerPartial('tracklist', tracklist);
-            handlebars.registerPartial('roomlist', roomlist);
-            handlebars.registerPartial('googleanalytics', googleanalytics);
-
-            const tracksTpl = handlebars.compile(fs.readFileSync(__dirname + '/templates/tracks.hbs').toString('utf-8'));
-            const scheduleTpl = handlebars.compile(fs.readFileSync(__dirname + '/templates/schedule.hbs').toString('utf-8'));
-            const roomstpl = handlebars.compile(fs.readFileSync(__dirname + '/templates/rooms.hbs').toString('utf-8'));
-            const speakerstpl = handlebars.compile(fs.readFileSync(__dirname + '/templates/speakers.hbs').toString('utf-8'));
-            const eventtpl = handlebars.compile(fs.readFileSync(__dirname + '/templates/event.hbs').toString('utf-8'));
-            const sessiontpl = handlebars.compile(fs.readFileSync(__dirname + '/templates/session.hbs').toString('utf-8'));
-            const codeOfConductTpl = handlebars.compile(fs.readFileSync(__dirname + '/templates/CoC.hbs').toString('utf-8'));
+            const tracksTpl = compileTemplate('tracks');
+            const scheduleTpl = compileTemplate('schedule');
+            const roomstpl = compileTemplate('rooms');
+            const speakerstpl = compileTemplate('speakers');
+            const eventtpl = compileTemplate('event');
+            const sessiontpl = compileTemplate('session');
+            const codeOfConductTpl = compileTemplate('CoC');
 
             if (mode === 'single') {
               logger.addLog('Info', 'Generating Single Page for each session', socket);

--- a/src/backend/generator.js
+++ b/src/backend/generator.js
@@ -19,30 +19,6 @@ const ftpDeployer = require('./ftpdeploy');
 const app = require('../app');
 let fold;
 
-const navbar = handlebars.compile(fs.readFileSync(__dirname + '/templates/partials/navbar.hbs').toString('utf-8'));
-const footer = handlebars.compile(fs.readFileSync(__dirname + '/templates/partials/footer.hbs').toString('utf-8'));
-const scroll = handlebars.compile(fs.readFileSync(__dirname + '/templates/partials/scroll.hbs').toString('utf-8'));
-const social = handlebars.compile(fs.readFileSync(__dirname + '/templates/partials/social.hbs').toString('utf-8'));
-const tracklist = handlebars.compile(fs.readFileSync(__dirname + '/templates/partials/tracklist.hbs').toString('utf-8'));
-const roomlist = handlebars.compile(fs.readFileSync(__dirname + '/templates/partials/roomlist.hbs').toString('utf-8'));
-const googleanalytics = handlebars.compile(fs.readFileSync(__dirname + '/templates/partials/googleanalytics.hbs').toString('utf-8'));
-
-handlebars.registerPartial('navbar', navbar);
-handlebars.registerPartial('footer', footer);
-handlebars.registerPartial('scroll', scroll);
-handlebars.registerPartial('social', social);
-handlebars.registerPartial('tracklist', tracklist);
-handlebars.registerPartial('roomlist', roomlist);
-handlebars.registerPartial('googleanalytics', googleanalytics);
-
-const tracksTpl = handlebars.compile(fs.readFileSync(__dirname + '/templates/tracks.hbs').toString('utf-8'));
-const scheduleTpl = handlebars.compile(fs.readFileSync(__dirname + '/templates/schedule.hbs').toString('utf-8'));
-const roomstpl = handlebars.compile(fs.readFileSync(__dirname + '/templates/rooms.hbs').toString('utf-8'));
-const speakerstpl = handlebars.compile(fs.readFileSync(__dirname + '/templates/speakers.hbs').toString('utf-8'));
-const eventtpl = handlebars.compile(fs.readFileSync(__dirname + '/templates/event.hbs').toString('utf-8'));
-const sessiontpl = handlebars.compile(fs.readFileSync(__dirname + '/templates/session.hbs').toString('utf-8'));
-const codeOfConductTpl = handlebars.compile(fs.readFileSync(__dirname + '/templates/CoC.hbs').toString('utf-8'));
-
 if (!String.linkify) {
   String.prototype.linkify = function() {
     const urlPattern = /\b(?:https?|ftp):\/\/[a-z0-9-+&@#\/%?=~_|!:,.;]*[a-z0-9-+&@#\/%=~_|]/gim;
@@ -445,6 +421,30 @@ exports.createDistDir = function(req, socket, callback) {
 
         function templateGenerate() {
           try {
+            const navbar = handlebars.compile(fs.readFileSync(__dirname + '/templates/partials/navbar.hbs').toString('utf-8'));
+            const footer = handlebars.compile(fs.readFileSync(__dirname + '/templates/partials/footer.hbs').toString('utf-8'));
+            const scroll = handlebars.compile(fs.readFileSync(__dirname + '/templates/partials/scroll.hbs').toString('utf-8'));
+            const social = handlebars.compile(fs.readFileSync(__dirname + '/templates/partials/social.hbs').toString('utf-8'));
+            const tracklist = handlebars.compile(fs.readFileSync(__dirname + '/templates/partials/tracklist.hbs').toString('utf-8'));
+            const roomlist = handlebars.compile(fs.readFileSync(__dirname + '/templates/partials/roomlist.hbs').toString('utf-8'));
+            const googleanalytics = handlebars.compile(fs.readFileSync(__dirname + '/templates/partials/googleanalytics.hbs').toString('utf-8'));
+
+            handlebars.registerPartial('navbar', navbar);
+            handlebars.registerPartial('footer', footer);
+            handlebars.registerPartial('scroll', scroll);
+            handlebars.registerPartial('social', social);
+            handlebars.registerPartial('tracklist', tracklist);
+            handlebars.registerPartial('roomlist', roomlist);
+            handlebars.registerPartial('googleanalytics', googleanalytics);
+
+            const tracksTpl = handlebars.compile(fs.readFileSync(__dirname + '/templates/tracks.hbs').toString('utf-8'));
+            const scheduleTpl = handlebars.compile(fs.readFileSync(__dirname + '/templates/schedule.hbs').toString('utf-8'));
+            const roomstpl = handlebars.compile(fs.readFileSync(__dirname + '/templates/rooms.hbs').toString('utf-8'));
+            const speakerstpl = handlebars.compile(fs.readFileSync(__dirname + '/templates/speakers.hbs').toString('utf-8'));
+            const eventtpl = handlebars.compile(fs.readFileSync(__dirname + '/templates/event.hbs').toString('utf-8'));
+            const sessiontpl = handlebars.compile(fs.readFileSync(__dirname + '/templates/session.hbs').toString('utf-8'));
+            const codeOfConductTpl = handlebars.compile(fs.readFileSync(__dirname + '/templates/CoC.hbs').toString('utf-8'));
+
             if (mode === 'single') {
               logger.addLog('Info', 'Generating Single Page for each session', socket);
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:

After editing one of the `.hbs` template files, a developer must restart their server, because the templates are only loaded at boot time.

When I first started working on the project, this was somewhat confusing. I would make changes to the template, and rebuild the site, but my changes did not appear!

#### Changes proposed in this pull request:

This PR loads the templates **from fresh** each time a website is generated.

I imagine this will have minimal effect on the live site, but it will make things easier for developers.

I mentioned this concern in issue #1882.

The PR also deduplicates some of the repeated long lines by extracting that behaviour into a function.

#### Concerns

This approach means we re-register already registered partials each time a site is generated. According to the [handlebars code](https://github.com/wycats/handlebars.js/blob/f21f900cf5eda5782781d7ff0ddeba0cd877a4bc/lib/handlebars/base.js#L56) I don't think this will cause any issues, it will simply overwrite the old partial.