### PR TITLE
Adds `All` tab on schedule page

### DIFF
--- a/src/backend/templates/schedule.hbs
+++ b/src/backend/templates/schedule.hbs
@@ -67,6 +67,7 @@
     <div class="date-list container">
       <div id="tabs" class="col-md-6 col-xs-12 col-sm-12 tabs no-js">
          <span class="tabs-nav">
+            <a id="all" href="#" class="all date-button tabs-nav-link is-active">All</a>
             {{#timeList}}
             <a id="{{slug}}" href="#" class="{{slug}} date-button tabs-nav-link">{{date}}</a>
             {{/timeList}}
@@ -1014,19 +1015,29 @@
       function viewsFilter(curView, date) {
         if(curView === 'list') {
           $('.day-filter').each(function () {
-            if($(this).attr('class').split(' ')[0] === date) {
+            if(date !== 'all') {
+              if ($(this).attr('class').split(' ')[0] === date) {
+                $(this).removeClass('hide');
+              } else {
+                $(this).addClass('hide');
+              }
+            }
+            else{
               $(this).removeClass('hide');
-            } else {
-              $(this).addClass('hide');
             }
           });
         }
         else if(curView === 'calendar') {
           $('.calendar').each(function () {
-            if($(this).attr('class').split(' ')[0] === date) {
+            if(date !== 'all') {
+              if ($(this).attr('class').split(' ')[0] === date) {
+                $(this).removeClass('hide');
+              } else {
+                $(this).addClass('hide');
+              }
+            }
+            else{
               $(this).removeClass('hide');
-            } else {
-              $(this).addClass('hide');
             }
           });
         }


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.

#### Short description of what this resolves:
Adds `All` tab on the schedule page for date filters

Screenshot:

![screenshot-2018-6-21 google io 2017](https://user-images.githubusercontent.com/21157929/41722588-a391939c-7586-11e8-8dce-91eb2b6ab56e.png)

Server Link:
https://openeveweb.herokuapp.com/
Fixes #1942 