### PR TITLE
Resets initial width of calendar after png download

### DIFF
--- a/src/backend/templates/schedule.hbs
+++ b/src/backend/templates/schedule.hbs
@@ -458,7 +458,8 @@
       var numberOfChildElements;
       var widthOfChild;
       var canvasWidth;
-      var initialWidth;
+      let initialWidth = [];
+      let count  = 0;
       var roomName;
       var trackName;
 
@@ -1090,15 +1091,17 @@
       $(".export-png").click(function() {
         let fullScheduler = true;
         if (isCalendarView === true) {
+          count = 0;
           $('.calendar').each(function() {
             if ($(this).attr('class').split(' ').indexOf('hide') <= 0) {
               $timeline = $(this);
-              initialWidth = $timeline.width();
+              initialWidth[count] = $timeline.width();
               numberOfChildElements = $timeline.find('.rooms')[0].childElementCount;
               numberOfChildElements = numberOfChildElements - 1;
               widthOfChild = $timeline.find('.room').width();
               canvasWidth = numberOfChildElements * widthOfChild + 50;
               $timeline.width(canvasWidth);
+              count++;
             }
           });
         } else {
@@ -1128,7 +1131,16 @@
             });
           },
         });
-        $timeline.width(initialWidth);
+
+        if (isCalendarView === true) {
+          count = 0;
+          $('.calendar').each(function () {
+            $timeline = $(this);
+            $timeline.width(initialWidth[count]);
+            count++;
+          });
+        }
+
       });
 
 


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.

#### Short description of what this resolves:
 Resets initial width of the calendar after png download

Preview Link: https://agbilotia1998.github.io/OWA/schedule.html
Fixes #1975 
