### PR TITLE
Fixes color of navbar icons in mobile view for dark theme

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -178,10 +178,30 @@ a {
 
 .navbar-toggle {
   border: 0;
-  color: $gray-dark;
+  color: $text-color;
   margin-left: 0;
   margin-top: 1em;
   padding: 6px 5px;
+}
+
+.navbar-toggle:hover {
+  color: $gray-dark;
+
+  #speakerslink {
+    color: $gray-dark;
+  }
+
+  .caret {
+    border-top: 4px solid $gray-dark;
+  }
+}
+
+#speakerslink {
+  color: $navbar-text-color;
+}
+
+.caret {
+  border-top: 4px solid $navbar-text-color;
 }
 
 .navbar-default .navbar-toggle .icon-bar {
@@ -792,7 +812,7 @@ a {
 }
 
 .active {
-  color: $black !important;
+  color: $black;
   font-weight: bold;
   text-decoration: underline;
 }


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.

#### Short description of what this resolves:
Fixes color of navbar icons in mobile view for the dark theme.

Screenshot:
![screenshot-2018-7-6 google io 2017](https://user-images.githubusercontent.com/21157929/42360249-50b8755c-8105-11e8-9e4c-0bc38afd91d5.png)

Preview Link: https://agbilotia1998.github.io/OWA-dark-theme/
Fixes #1990 
