### PR TITLE
removing link on More on in dropdown menu

### DIFF
--- a/src/www/index.html
+++ b/src/www/index.html
@@ -258,7 +258,7 @@
         </div>
         <hr style="margin: 10px">
         <div style="display: flex;justify-content: center;align-items: center; margin: 0 0 -20px 0">
-          <a href="https://labs.fossasia.org/" target="_blank" style="text-decoration: none;color: #737373">More on labs.fossasia.org</a>
+          More on&nbsp;<a href="https://labs.fossasia.org/" target="_blank" style="text-decoration: none;color: #737373">labs.fossasia.org</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
In dropdown menu when we hover on More on link description is showing. 

The link should only on labs.fossasia.org

Fixes: #1994 