### PR TITLE
Calendar view: Shows speaker heading only if data is available

### DIFF
--- a/src/backend/_scss/application.scss
+++ b/src/backend/_scss/application.scss
@@ -2245,8 +2245,9 @@ a.skip:hover {
   overflow-y: auto;
 }
 
-#calendar-seesion-speakers-list {
+.calendar-session-speakers-list {
   max-height: 350px;
+  overflow-y: auto;
 }
 
 .slides {

--- a/src/backend/templates/schedule.hbs
+++ b/src/backend/templates/schedule.hbs
@@ -348,8 +348,10 @@
                               <div class="pop-speakers">
                                <div class="pop-over row">
                                  <hr>
-                                 <h4 class="text"><strong>Speakers</strong></h4>
-                                 <div id= "calendar-seesion-speakers-list" class="session-speakers-list">
+                                 {{#if speakers_list}}
+                                    <h4 class="text"><strong>Speakers</strong></h4>
+                                 {{/if}}
+                                 <div class="calendar-session-speakers-list">
                                  {{#speakers_list}}
                                    <a href="speakers.html#{{nameIdSlug}}">
                                      <div class="session-speakers-less">
@@ -505,6 +507,7 @@
         });
       });
       let featuresWidth;
+
       $('.schedule-margin').each(function() {
         featuresWidth = $(this).children('.features').width() + 2;
         $(this).css('padding-right', featuresWidth + 'px');


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.

#### Short description of what this resolves:
Shows speaker heading in calendar view only if data is available.

Screenshot:
![screenshot from 2018-07-09 21-53-28](https://user-images.githubusercontent.com/21157929/42463108-dc578e9e-83c2-11e8-98aa-f8f5b59bc8eb.png)

Server Link: https://openeveweb.herokuapp.com/
Fixes #2006 
