### PR TITLE
Fixes the position of bookmark icon in single session style apps

### DIFF
--- a/src/backend/templates/session.hbs
+++ b/src/backend/templates/session.hbs
@@ -54,7 +54,7 @@
           <div class="session-content">
             <div class="sizeevent event event-title" id="title-{{session_id}}" style="background-color:{{color}}; color:{{font_color}}; margin-right:0px; cursor:unset;">
               {{title}} {{#if type}} ({{type}}) {{/if}} | {{track_title}}
-              <a class="bookmark">
+              <a class="bookmark features">
                 <i class="fa fa-star" aria-hidden="true">
                 </i>
               </a>


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.

#### Short description of what this resolves:
Fixes the position of bookmark icon in single session style apps

Screenshot:
![screenshot_2018-07-11 screenshot](https://user-images.githubusercontent.com/21157929/42556564-a480dadc-8509-11e8-9248-1a585a67ecfc.png)

Server link: http://openeveweb.herokuapp.com/
API endpoint: https://raw.githubusercontent.com/fossasia/open-event/master/sample/MozillaAllHands17
Fixes #2010 
