### PR TITLE
Enables dynamic linking for rooms filter on tracks page

### DIFF
--- a/src/backend/templates/tracks.hbs
+++ b/src/backend/templates/tracks.hbs
@@ -473,6 +473,7 @@
                sidebarDiv.addClass('in');
 
           roomName = $(this).text().trim();
+          window.location.href = url + '#' + roomName;
           trackFilterMode = false;
           roomFilterMode = true;
 


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.

#### Short description of what this resolves:
The selenium tests are failing due to dynamic linking of filters being missed on tracks page, this PR adds the dynamic linking of room filters.

Server-link: https://open-event-webapp.herokuapp.com/
Test endpoint: https://raw.githubusercontent.com/fossasia/open-event/master/sample/GoogleIO17
Fixes #2043 
