### PR TITLE
Github dependency renamed to 'octokit/rest'

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,8 +2,34 @@
   "name": "open-event-webapp",
   "version": "2.0.0",
   "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
+    "@octokit/rest": {
+      "version": "15.12.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.12.1.tgz",
+      "integrity": "sha512-Nn3o2iVHHWNbw8MSOWTa67/6N1e7muaDWVMWr3FXUDSlMzB3lXlr6EdO1hwfUzpmZAkNc1rFN4y0tuy38gtd+A==",
+      "dependencies": {
+        "agent-base": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+          "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg=="
+        },
+        "debug": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg=="
+        },
+        "https-proxy-agent": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+          "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ=="
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
     "abbrev": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
@@ -12,11 +38,7 @@
     "accepts": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-      "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
-      "requires": {
-        "mime-types": "2.1.15",
-        "negotiator": "0.6.1"
-      }
+      "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo="
     },
     "acorn": {
       "version": "5.6.2",
@@ -29,9 +51,6 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
-      "requires": {
-        "acorn": "3.3.0"
-      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
@@ -56,23 +75,10 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
     },
-    "agent-base": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
-      "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
-      "requires": {
-        "extend": "3.0.1",
-        "semver": "5.0.3"
-      }
-    },
     "ajv": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "requires": {
-        "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
-      }
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY="
     },
     "ajv-keywords": {
       "version": "2.1.1",
@@ -83,12 +89,7 @@
     "align-text": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
-      }
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc="
     },
     "amdefine": {
       "version": "1.0.1",
@@ -119,31 +120,12 @@
     "archiver": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
-      "integrity": "sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI=",
-      "requires": {
-        "archiver-utils": "1.3.0",
-        "async": "2.4.1",
-        "buffer-crc32": "0.2.13",
-        "glob": "7.1.2",
-        "lodash": "4.17.4",
-        "readable-stream": "2.2.9",
-        "tar-stream": "1.5.4",
-        "walkdir": "0.0.11",
-        "zip-stream": "1.1.1"
-      }
+      "integrity": "sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI="
     },
     "archiver-utils": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
-      "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
-      "requires": {
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "lazystream": "1.0.0",
-        "lodash": "4.17.4",
-        "normalize-path": "2.1.1",
-        "readable-stream": "2.2.9"
-      }
+      "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ="
     },
     "archy": {
       "version": "1.0.0",
@@ -153,28 +135,18 @@
     "are-we-there-yet": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-      "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.2.9"
-      }
+      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0="
     },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "1.0.3"
-      }
+      "dev": true
     },
     "arr-diff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "requires": {
-        "arr-flatten": "1.0.3"
-      }
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8="
     },
     "arr-flatten": {
       "version": "1.0.3",
@@ -200,10 +172,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "1.0.3"
-      }
+      "dev": true
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -244,10 +213,7 @@
     "async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
-      "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c=",
-      "requires": {
-        "lodash": "4.17.4"
-      }
+      "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c="
     },
     "async-foreach": {
       "version": "0.1.3",
@@ -257,18 +223,12 @@
     "async.ensureasync": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/async.ensureasync/-/async.ensureasync-0.5.2.tgz",
-      "integrity": "sha1-w8fkpOmzHZaHXVa4UEWYRG4eMF0=",
-      "requires": {
-        "async.util.ensureasync": "0.5.2"
-      }
+      "integrity": "sha1-w8fkpOmzHZaHXVa4UEWYRG4eMF0="
     },
     "async.queue": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/async.queue/-/async.queue-0.5.2.tgz",
-      "integrity": "sha1-jV2QgS4UgQZrwJBOjMFxKxfDvXw=",
-      "requires": {
-        "async.util.queue": "0.5.2"
-      }
+      "integrity": "sha1-jV2QgS4UgQZrwJBOjMFxKxfDvXw="
     },
     "async.util.arrayeach": {
       "version": "0.5.2",
@@ -278,11 +238,7 @@
     "async.util.ensureasync": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/async.util.ensureasync/-/async.util.ensureasync-0.5.2.tgz",
-      "integrity": "sha1-EJB/LL0GegYfma5tIuCM7TDbDWg=",
-      "requires": {
-        "async.util.restparam": "0.5.2",
-        "async.util.setimmediate": "0.5.2"
-      }
+      "integrity": "sha1-EJB/LL0GegYfma5tIuCM7TDbDWg="
     },
     "async.util.isarray": {
       "version": "0.5.2",
@@ -307,15 +263,7 @@
     "async.util.queue": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/async.util.queue/-/async.util.queue-0.5.2.tgz",
-      "integrity": "sha1-V/Zavho83yc9MavSirlUJfgiLuU=",
-      "requires": {
-        "async.util.arrayeach": "0.5.2",
-        "async.util.isarray": "0.5.2",
-        "async.util.map": "0.5.2",
-        "async.util.noop": "0.5.2",
-        "async.util.onlyonce": "0.5.2",
-        "async.util.setimmediate": "0.5.2"
-      }
+      "integrity": "sha1-V/Zavho83yc9MavSirlUJfgiLuU="
     },
     "async.util.restparam": {
       "version": "0.5.2",
@@ -336,17 +284,6 @@
       "version": "2.62.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.62.0.tgz",
       "integrity": "sha1-mFCNP5Oq8/dPGMo7jP46Eb2tGl8=",
-      "requires": {
-        "buffer": "5.0.6",
-        "crypto-browserify": "1.0.9",
-        "jmespath": "0.15.0",
-        "querystring": "0.2.0",
-        "sax": "1.2.1",
-        "url": "0.10.3",
-        "uuid": "3.0.1",
-        "xml2js": "0.4.17",
-        "xmlbuilder": "4.2.1"
-      },
       "dependencies": {
         "uuid": {
           "version": "3.0.1",
@@ -368,53 +305,17 @@
     "babel-code-frame": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-      "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.1"
-      }
+      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ="
     },
     "babel-core": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
-      "integrity": "sha1-jEKFZNzh4fQfszfsNPTDsCK1rYM=",
-      "requires": {
-        "babel-code-frame": "6.22.0",
-        "babel-generator": "6.24.1",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.24.1",
-        "babel-traverse": "6.24.1",
-        "babel-types": "6.24.1",
-        "babylon": "6.17.1",
-        "convert-source-map": "1.5.0",
-        "debug": "2.6.8",
-        "json5": "0.5.1",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.7",
-        "slash": "1.0.0",
-        "source-map": "0.5.6"
-      }
+      "integrity": "sha1-jEKFZNzh4fQfszfsNPTDsCK1rYM="
     },
     "babel-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
       "integrity": "sha1-5xX0hsWN7SVknYiJRNUqoHxdlJc=",
-      "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.4",
-        "source-map": "0.5.6",
-        "trim-right": "1.0.1"
-      },
       "dependencies": {
         "jsesc": {
           "version": "1.3.0",
@@ -426,433 +327,207 @@
     "babel-helper-call-delegate": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-      "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-traverse": "6.24.1",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340="
     },
     "babel-helper-define-map": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
-      "integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1",
-        "lodash": "4.17.4"
-      }
+      "integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA="
     },
     "babel-helper-function-name": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.24.1",
-        "babel-traverse": "6.24.1",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk="
     },
     "babel-helper-get-function-arity": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0="
     },
     "babel-helper-hoist-variables": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY="
     },
     "babel-helper-optimise-call-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc="
     },
     "babel-helper-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
-      "integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1",
-        "lodash": "4.17.4"
-      }
+      "integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg="
     },
     "babel-helper-replace-supers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-      "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.24.1",
-        "babel-traverse": "6.24.1",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo="
     },
     "babel-helpers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.24.1"
-      }
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI="
     },
     "babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4="
     },
     "babel-plugin-check-es2015-constants": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o="
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE="
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE="
     },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
-      "integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.24.1",
-        "babel-traverse": "6.24.1",
-        "babel-types": "6.24.1",
-        "lodash": "4.17.4"
-      }
+      "integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY="
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-      "requires": {
-        "babel-helper-define-map": "6.24.1",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.24.1",
-        "babel-traverse": "6.24.1",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs="
     },
     "babel-plugin-transform-es2015-computed-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.24.1"
-      }
+      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM="
     },
     "babel-plugin-transform-es2015-destructuring": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0="
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4="
     },
     "babel-plugin-transform-es2015-for-of": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE="
     },
     "babel-plugin-transform-es2015-function-name": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos="
     },
     "babel-plugin-transform-es2015-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4="
     },
     "babel-plugin-transform-es2015-modules-amd": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-      "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.24.1"
-      }
+      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ="
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
-      "integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
-      "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.24.1",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4="
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-      "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.24.1"
-      }
+      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM="
     },
     "babel-plugin-transform-es2015-modules-umd": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-      "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.24.1"
-      }
+      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg="
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-      "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40="
     },
     "babel-plugin-transform-es2015-parameters": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-      "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.24.1",
-        "babel-traverse": "6.24.1",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys="
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA="
     },
     "babel-plugin-transform-es2015-spread": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE="
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-      "requires": {
-        "babel-helper-regex": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw="
     },
     "babel-plugin-transform-es2015-template-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0="
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I="
     },
     "babel-plugin-transform-es2015-unicode-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-      "requires": {
-        "babel-helper-regex": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "regexpu-core": "2.0.0"
-      }
+      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek="
     },
     "babel-plugin-transform-regenerator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
-      "integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg=",
-      "requires": {
-        "regenerator-transform": "0.9.11"
-      }
+      "integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg="
     },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g="
     },
     "babel-preset-es2015": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
-      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
-      "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.24.1",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.24.1"
-      }
+      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk="
     },
     "babel-register": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
-      "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
-      "requires": {
-        "babel-core": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "core-js": "2.4.1",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.15"
-      }
+      "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118="
     },
     "babel-runtime": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-      "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
-      "requires": {
-        "core-js": "2.4.1",
-        "regenerator-runtime": "0.10.5"
-      }
+      "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs="
     },
     "babel-template": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
-      "integrity": "sha1-BK5RTx+Ts6JTfyoPYKWkX7gwgzM=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-traverse": "6.24.1",
-        "babel-types": "6.24.1",
-        "babylon": "6.17.1",
-        "lodash": "4.17.4"
-      }
+      "integrity": "sha1-BK5RTx+Ts6JTfyoPYKWkX7gwgzM="
     },
     "babel-traverse": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
-      "integrity": "sha1-qzZnP9NW+aCUhlnnszjV/q2zFpU=",
-      "requires": {
-        "babel-code-frame": "6.22.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1",
-        "babylon": "6.17.1",
-        "debug": "2.6.8",
-        "globals": "9.17.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4"
-      }
+      "integrity": "sha1-qzZnP9NW+aCUhlnnszjV/q2zFpU="
     },
     "babel-types": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
-      "integrity": "sha1-oTaHncFbNga9oNkMH8dDBML/CXU=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.4",
-        "to-fast-properties": "1.0.3"
-      }
+      "integrity": "sha1-oTaHncFbNga9oNkMH8dDBML/CXU="
     },
     "babylon": {
       "version": "6.17.1",
@@ -888,49 +563,37 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "optional": true,
-      "requires": {
-        "tweetnacl": "0.14.5"
-      }
+      "optional": true
     },
     "bee-queue": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/bee-queue/-/bee-queue-1.2.2.tgz",
-      "integrity": "sha512-Nw6VXHkAdfnMEp5bdffTSZEBnHuZSoRLjwmurfaQp6xmcxP+XsaqKClH1/XLmoAkrOuW40j9mLGlsLR/25ljwQ==",
-      "requires": {
-        "promise-callbacks": "3.1.0",
-        "redis": "2.8.0"
-      }
+      "integrity": "sha512-Nw6VXHkAdfnMEp5bdffTSZEBnHuZSoRLjwmurfaQp6xmcxP+XsaqKClH1/XLmoAkrOuW40j9mLGlsLR/25ljwQ=="
     },
     "beeper": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
       "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
     },
+    "before-after-hook": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.1.0.tgz",
+      "integrity": "sha512-VOMDtYPwLbIncTxNoSzRyvaMxtXmLWLUqr8k5AfC1BzLk34HvBXaQX8snOwQZ4c0aX8aSERqtJSiI9/m2u5kuA=="
+    },
     "better-assert": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-      "requires": {
-        "callsite": "1.0.0"
-      }
+      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI="
     },
     "binary": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
-      "requires": {
-        "buffers": "0.1.1",
-        "chainsaw": "0.1.0"
-      }
+      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk="
     },
     "bl": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
-      "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
-      "requires": {
-        "readable-stream": "2.2.9"
-      }
+      "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4="
     },
     "blob": {
       "version": "0.0.4",
@@ -940,10 +603,7 @@
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "requires": {
-        "inherits": "2.0.3"
-      }
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo="
     },
     "bluebird": {
       "version": "3.5.0",
@@ -954,36 +614,18 @@
       "version": "1.17.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",
       "integrity": "sha1-+IkqvI+eYn1Crtr7yma/WrmRBO4=",
-      "requires": {
-        "bytes": "2.4.0",
-        "content-type": "1.0.2",
-        "debug": "2.6.7",
-        "depd": "1.1.0",
-        "http-errors": "1.6.1",
-        "iconv-lite": "0.4.15",
-        "on-finished": "2.3.0",
-        "qs": "6.4.0",
-        "raw-body": "2.2.0",
-        "type-is": "1.6.15"
-      },
       "dependencies": {
         "debug": {
           "version": "2.6.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "requires": {
-            "ms": "2.0.0"
-          }
+          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4="
         }
       }
     },
     "boom": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "requires": {
-        "hoek": "2.16.3"
-      }
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
     },
     "bottleneck": {
       "version": "1.15.1",
@@ -993,30 +635,22 @@
     "brace-expansion": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-      "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
-      "requires": {
-        "balanced-match": "0.4.2",
-        "concat-map": "0.0.1"
-      }
+      "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k="
     },
     "braces": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
-      }
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc="
+    },
+    "btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
     },
     "buffer": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.0.6.tgz",
-      "integrity": "sha1-LqZp9+7Atu2gWwj4tf9mGyhXNYg=",
-      "requires": {
-        "base64-js": "1.2.0",
-        "ieee754": "1.1.8"
-      }
+      "integrity": "sha1-LqZp9+7Atu2gWwj4tf9mGyhXNYg="
     },
     "buffer-crc32": {
       "version": "0.2.13",
@@ -1042,10 +676,7 @@
     "bufferstreams": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.1.1.tgz",
-      "integrity": "sha1-AWE3MGCsWYjv+ZBYcxEU9uGV1R4=",
-      "requires": {
-        "readable-stream": "2.2.9"
-      }
+      "integrity": "sha1-AWE3MGCsWYjv+ZBYcxEU9uGV1R4="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -1061,10 +692,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true,
-      "requires": {
-        "callsites": "0.2.0"
-      }
+      "dev": true
     },
     "callsite": {
       "version": "1.0.0",
@@ -1080,11 +708,7 @@
     "camel-case": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
-      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
-      "requires": {
-        "no-case": "2.3.1",
-        "upper-case": "1.1.3"
-      }
+      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M="
     },
     "camelcase": {
       "version": "2.1.1",
@@ -1094,11 +718,7 @@
     "camelcase-keys": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
-      }
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc="
     },
     "capture-stack-trace": {
       "version": "1.0.0",
@@ -1114,10 +734,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caw/-/caw-2.0.0.tgz",
       "integrity": "sha1-Efi93C+AFGmVLV4yJbqYSVovoP8=",
-      "requires": {
-        "get-proxy": "1.1.0",
-        "tunnel-agent": "0.4.3"
-      },
       "dependencies": {
         "tunnel-agent": {
           "version": "0.4.3",
@@ -1130,44 +746,22 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "optional": true,
-      "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
-      }
+      "optional": true
     },
     "chai": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.0.1.tgz",
-      "integrity": "sha1-nkHoCOF6fxCAdyHirFpYnVuwkII=",
-      "requires": {
-        "assertion-error": "1.0.2",
-        "check-error": "1.0.2",
-        "deep-eql": "2.0.2",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.0",
-        "type-detect": "4.0.3"
-      }
+      "integrity": "sha1-nkHoCOF6fxCAdyHirFpYnVuwkII="
     },
     "chainsaw": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
-      "requires": {
-        "traverse": "0.3.9"
-      }
+      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg="
     },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
-      }
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
     },
     "chardet": {
       "version": "0.4.2",
@@ -1195,19 +789,13 @@
     "clean-css": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.3.tgz",
-      "integrity": "sha1-B8/omA7bINRV3cI6rc8eBMblCc4=",
-      "requires": {
-        "source-map": "0.5.6"
-      }
+      "integrity": "sha1-B8/omA7bINRV3cI6rc8eBMblCc4="
     },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "dev": true,
-      "requires": {
-        "restore-cursor": "2.0.0"
-      }
+      "dev": true
     },
     "cli-width": {
       "version": "2.2.0",
@@ -1219,12 +807,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "optional": true,
-      "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
-        "wordwrap": "0.0.2"
-      }
+      "optional": true
     },
     "clone": {
       "version": "1.0.2",
@@ -1244,12 +827,7 @@
     "cloneable-readable": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
-      "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
-      "requires": {
-        "inherits": "2.0.3",
-        "process-nextick-args": "1.0.7",
-        "through2": "2.0.3"
-      }
+      "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc="
     },
     "co": {
       "version": "4.6.0",
@@ -1264,19 +842,12 @@
     "color": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/color/-/color-1.0.3.tgz",
-      "integrity": "sha1-5I6DLYXxTvaU+0aIEcLVz+cptV0=",
-      "requires": {
-        "color-convert": "1.9.0",
-        "color-string": "1.5.2"
-      }
+      "integrity": "sha1-5I6DLYXxTvaU+0aIEcLVz+cptV0="
     },
     "color-convert": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-      "requires": {
-        "color-name": "1.1.2"
-      }
+      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o="
     },
     "color-name": {
       "version": "1.1.2",
@@ -1286,27 +857,17 @@
     "color-string": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.2.tgz",
-      "integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
-      "requires": {
-        "color-name": "1.1.2",
-        "simple-swizzle": "0.2.2"
-      }
+      "integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k="
     },
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "requires": {
-        "delayed-stream": "1.0.0"
-      }
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
     },
     "commander": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "requires": {
-        "graceful-readlink": "1.0.1"
-      }
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q="
     },
     "component-bind": {
       "version": "1.0.0",
@@ -1326,34 +887,17 @@
     "compress-commons": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.0.tgz",
-      "integrity": "sha1-WFhwku8g03y1i68AARLJJ4/3O58=",
-      "requires": {
-        "buffer-crc32": "0.2.13",
-        "crc32-stream": "2.0.0",
-        "normalize-path": "2.1.1",
-        "readable-stream": "2.2.9"
-      }
+      "integrity": "sha1-WFhwku8g03y1i68AARLJJ4/3O58="
     },
     "compressible": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.10.tgz",
-      "integrity": "sha1-/tocf3YXkScyspv4zyYlKiC57s0=",
-      "requires": {
-        "mime-db": "1.27.0"
-      }
+      "integrity": "sha1-/tocf3YXkScyspv4zyYlKiC57s0="
     },
     "compression": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.6.2.tgz",
       "integrity": "sha1-zOsSHsydCcUtetDDNQ6pPd1AK8M=",
-      "requires": {
-        "accepts": "1.3.3",
-        "bytes": "2.3.0",
-        "compressible": "2.0.10",
-        "debug": "2.2.0",
-        "on-headers": "1.0.1",
-        "vary": "1.1.1"
-      },
       "dependencies": {
         "bytes": {
           "version": "2.3.0",
@@ -1363,10 +907,7 @@
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "requires": {
-            "ms": "0.7.1"
-          }
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo="
         },
         "ms": {
           "version": "0.7.1",
@@ -1384,21 +925,12 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
-      "requires": {
-        "buffer-from": "1.1.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.2.9",
-        "typedarray": "0.0.6"
-      }
+      "dev": true
     },
     "concat-with-sourcemaps": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz",
-      "integrity": "sha1-9Vs74q60dgGxCi1SWcz7cP0vHdY=",
-      "requires": {
-        "source-map": "0.5.6"
-      }
+      "integrity": "sha1-9Vs74q60dgGxCi1SWcz7cP0vHdY="
     },
     "connect-domain": {
       "version": "0.5.0",
@@ -1434,11 +966,7 @@
     "cookie-parser": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.3.tgz",
-      "integrity": "sha1-D+MfoZ0AC5X0qt8fU/3CuKIDuqU=",
-      "requires": {
-        "cookie": "0.3.1",
-        "cookie-signature": "1.0.6"
-      }
+      "integrity": "sha1-D+MfoZ0AC5X0qt8fU/3CuKIDuqU="
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -1463,47 +991,29 @@
     "crc32-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
-      "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
-      "requires": {
-        "crc": "3.4.4",
-        "readable-stream": "2.2.9"
-      }
+      "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ="
     },
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-      "requires": {
-        "capture-stack-trace": "1.0.0"
-      }
+      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y="
     },
     "cross-spawn": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
       "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
-      "requires": {
-        "lru-cache": "4.0.2",
-        "which": "1.2.14"
-      },
       "dependencies": {
         "lru-cache": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
-          "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
-          "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
-          }
+          "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4="
         }
       }
     },
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "requires": {
-        "boom": "2.10.1"
-      }
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
     },
     "crypto-browserify": {
       "version": "1.0.9",
@@ -1513,18 +1023,12 @@
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "requires": {
-        "array-find-index": "1.0.2"
-      }
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o="
     },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "1.0.0"
-      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -1541,10 +1045,7 @@
     "debug": {
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "requires": {
-        "ms": "2.0.0"
-      }
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
     },
     "decamelize": {
       "version": "1.2.0",
@@ -1555,15 +1056,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.0.tgz",
       "integrity": "sha1-rjvLfjTGWHmt/nfhnDD4ZgK0vbA=",
-      "requires": {
-        "binary": "0.3.0",
-        "graceful-fs": "4.1.11",
-        "mkpath": "0.1.0",
-        "nopt": "3.0.6",
-        "q": "1.5.0",
-        "readable-stream": "1.1.14",
-        "touch": "0.0.3"
-      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -1573,13 +1065,7 @@
         "readable-stream": {
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk="
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -1592,9 +1078,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-2.0.2.tgz",
       "integrity": "sha1-sbrAblbwp2d3aG1Qyf63XC7XZ5o=",
-      "requires": {
-        "type-detect": "3.0.0"
-      },
       "dependencies": {
         "type-detect": {
           "version": "3.0.0",
@@ -1617,19 +1100,12 @@
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-      "requires": {
-        "clone": "1.0.2"
-      }
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730="
     },
     "define-properties": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
-      },
       "dependencies": {
         "object-keys": {
           "version": "1.0.11",
@@ -1643,15 +1119,6 @@
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
-      "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.1",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.1"
-      },
       "dependencies": {
         "object-assign": {
           "version": "4.1.1",
@@ -1689,27 +1156,18 @@
     "detect-file": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
-      "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
-      "requires": {
-        "fs-exists-sync": "0.1.0"
-      }
+      "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM="
     },
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "requires": {
-        "repeating": "2.0.1"
-      }
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg="
     },
     "doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-      "dev": true,
-      "requires": {
-        "esutils": "2.0.2"
-      }
+      "dev": true
     },
     "double-ended-queue": {
       "version": "2.1.0-0",
@@ -1725,9 +1183,6 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-      "requires": {
-        "readable-stream": "1.1.14"
-      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -1737,13 +1192,7 @@
         "readable-stream": {
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk="
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -1761,10 +1210,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "optional": true,
-      "requires": {
-        "jsbn": "0.1.1"
-      }
+      "optional": true
     },
     "ee-first": {
       "version": "1.1.1",
@@ -1779,93 +1225,52 @@
     "encoding": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "0.4.15"
-      }
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s="
     },
     "end-of-stream": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-      "requires": {
-        "once": "1.4.0"
-      }
+      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY="
     },
     "engine.io": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.1.0.tgz",
-      "integrity": "sha1-XKQ4486f28kVxKIcjdnhJmcG5X4=",
-      "requires": {
-        "accepts": "1.3.3",
-        "base64id": "1.0.0",
-        "cookie": "0.3.1",
-        "debug": "2.6.8",
-        "engine.io-parser": "2.1.1",
-        "uws": "0.14.5",
-        "ws": "2.3.1"
-      }
+      "integrity": "sha1-XKQ4486f28kVxKIcjdnhJmcG5X4="
     },
     "engine.io-client": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.1.1.tgz",
-      "integrity": "sha1-QVqYUrrbFPoAj6PvHjFgjbZ2EyU=",
-      "requires": {
-        "component-emitter": "1.2.1",
-        "component-inherit": "0.0.3",
-        "debug": "2.6.8",
-        "engine.io-parser": "2.1.1",
-        "has-cors": "1.1.0",
-        "indexof": "0.0.1",
-        "parsejson": "0.0.3",
-        "parseqs": "0.0.5",
-        "parseuri": "0.0.5",
-        "ws": "2.3.1",
-        "xmlhttprequest-ssl": "1.5.3",
-        "yeast": "0.1.2"
-      }
+      "integrity": "sha1-QVqYUrrbFPoAj6PvHjFgjbZ2EyU="
     },
     "engine.io-parser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.1.tgz",
-      "integrity": "sha1-4Ps/DgRi9/WLt3waUun1p+JuRmg=",
-      "requires": {
-        "after": "0.8.2",
-        "arraybuffer.slice": "0.0.6",
-        "base64-arraybuffer": "0.1.5",
-        "blob": "0.0.4",
-        "has-binary2": "1.0.2"
-      }
+      "integrity": "sha1-4Ps/DgRi9/WLt3waUun1p+JuRmg="
     },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "requires": {
-        "is-arrayish": "0.2.1"
-      }
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw="
     },
     "es-abstract": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
-      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
-      "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.3",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
-      }
+      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA=="
     },
     "es-to-primitive": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
-      }
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0="
+    },
+    "es6-promise": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
+      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -1882,58 +1287,12 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
       "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
-      "requires": {
-        "ajv": "5.5.2",
-        "babel-code-frame": "6.22.0",
-        "chalk": "2.4.1",
-        "concat-stream": "1.6.2",
-        "cross-spawn": "5.1.0",
-        "debug": "3.1.0",
-        "doctrine": "2.1.0",
-        "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "1.0.0",
-        "espree": "3.5.4",
-        "esquery": "1.0.1",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.2",
-        "globals": "11.5.0",
-        "ignore": "3.3.8",
-        "imurmurhash": "0.1.4",
-        "inquirer": "3.3.0",
-        "is-resolvable": "1.1.0",
-        "js-yaml": "3.12.0",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "7.0.0",
-        "progress": "2.0.0",
-        "regexpp": "1.1.0",
-        "require-uncached": "1.0.3",
-        "semver": "5.5.0",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "4.0.2",
-        "text-table": "0.2.0"
-      },
       "dependencies": {
         "ajv": {
           "version": "5.5.2",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.1.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
-          }
+          "dev": true
         },
         "ansi-regex": {
           "version": "3.0.0",
@@ -1945,41 +1304,25 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.0"
-          }
+          "dev": true
         },
         "chalk": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
-          }
+          "dev": true
         },
         "cross-spawn": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "4.1.3",
-            "shebang-command": "1.2.0",
-            "which": "1.2.14"
-          }
+          "dev": true
         },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
+          "dev": true
         },
         "globals": {
           "version": "11.5.0",
@@ -1991,11 +1334,7 @@
           "version": "4.1.3",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
           "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
-          }
+          "dev": true
         },
         "semver": {
           "version": "5.5.0",
@@ -2007,19 +1346,13 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
+          "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-          "dev": true,
-          "requires": {
-            "has-flag": "3.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -2027,11 +1360,7 @@
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-      "dev": true,
-      "requires": {
-        "esrecurse": "4.2.1",
-        "estraverse": "4.2.0"
-      }
+      "dev": true
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
@@ -2043,11 +1372,7 @@
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
-      "dev": true,
-      "requires": {
-        "acorn": "5.6.2",
-        "acorn-jsx": "3.0.1"
-      }
+      "dev": true
     },
     "esprima": {
       "version": "4.0.0",
@@ -2059,19 +1384,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
-      "dev": true,
-      "requires": {
-        "estraverse": "4.2.0"
-      }
+      "dev": true
     },
     "esrecurse": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-      "dev": true,
-      "requires": {
-        "estraverse": "4.2.0"
-      }
+      "dev": true
     },
     "estraverse": {
       "version": "4.2.0",
@@ -2092,69 +1411,27 @@
     "expand-brackets": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "requires": {
-        "is-posix-bracket": "0.1.1"
-      }
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s="
     },
     "expand-range": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "requires": {
-        "fill-range": "2.2.3"
-      }
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc="
     },
     "expand-tilde": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
-      "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
-      "requires": {
-        "os-homedir": "1.0.2"
-      }
+      "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk="
     },
     "express": {
       "version": "4.15.3",
       "resolved": "https://registry.npmjs.org/express/-/express-4.15.3.tgz",
       "integrity": "sha1-urZdDwOqgMNYQIly/HAPkWlEtmI=",
-      "requires": {
-        "accepts": "1.3.3",
-        "array-flatten": "1.1.1",
-        "content-disposition": "0.5.2",
-        "content-type": "1.0.2",
-        "cookie": "0.3.1",
-        "cookie-signature": "1.0.6",
-        "debug": "2.6.7",
-        "depd": "1.1.0",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.0",
-        "finalhandler": "1.0.3",
-        "fresh": "0.5.0",
-        "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.1",
-        "path-to-regexp": "0.1.7",
-        "proxy-addr": "1.1.4",
-        "qs": "6.4.0",
-        "range-parser": "1.2.0",
-        "send": "0.15.3",
-        "serve-static": "1.12.3",
-        "setprototypeof": "1.0.3",
-        "statuses": "1.3.1",
-        "type-is": "1.6.15",
-        "utils-merge": "1.0.0",
-        "vary": "1.1.1"
-      },
       "dependencies": {
         "debug": {
           "version": "2.6.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "requires": {
-            "ms": "2.0.0"
-          }
+          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4="
         }
       }
     },
@@ -2162,25 +1439,11 @@
       "version": "1.15.3",
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.15.3.tgz",
       "integrity": "sha1-21RfBDWnsbIorgLagZf2UUFzXGc=",
-      "requires": {
-        "cookie": "0.3.1",
-        "cookie-signature": "1.0.6",
-        "crc": "3.4.4",
-        "debug": "2.6.7",
-        "depd": "1.1.0",
-        "on-headers": "1.0.1",
-        "parseurl": "1.3.1",
-        "uid-safe": "2.1.4",
-        "utils-merge": "1.0.0"
-      },
       "dependencies": {
         "debug": {
           "version": "2.6.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "requires": {
-            "ms": "2.0.0"
-          }
+          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4="
         }
       }
     },
@@ -2194,39 +1457,25 @@
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
-      "requires": {
-        "chardet": "0.4.2",
-        "iconv-lite": "0.4.23",
-        "tmp": "0.0.33"
-      },
       "dependencies": {
         "iconv-lite": {
           "version": "0.4.23",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-          "dev": true,
-          "requires": {
-            "safer-buffer": "2.1.2"
-          }
+          "dev": true
         },
         "tmp": {
           "version": "0.0.33",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
           "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "1.0.2"
-          }
+          "dev": true
         }
       }
     },
     "extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "requires": {
-        "is-extglob": "1.0.0"
-      }
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE="
     },
     "extsprintf": {
       "version": "1.0.2",
@@ -2236,11 +1485,7 @@
     "fancy-log": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-      "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
-      "requires": {
-        "chalk": "1.1.3",
-        "time-stamp": "1.1.0"
-      }
+      "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg="
     },
     "fast-deep-equal": {
       "version": "1.1.0",
@@ -2264,20 +1509,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "1.0.5"
-      }
+      "dev": true
     },
     "file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
-      "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
-      },
       "dependencies": {
         "object-assign": {
           "version": "4.1.1",
@@ -2295,36 +1533,17 @@
     "fill-range": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.6",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
-      }
+      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM="
     },
     "finalhandler": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
       "integrity": "sha1-70fneVDpmXgOhgIqVg4yF+DQzIk=",
-      "requires": {
-        "debug": "2.6.7",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.1",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
-      },
       "dependencies": {
         "debug": {
           "version": "2.6.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "requires": {
-            "ms": "2.0.0"
-          }
+          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4="
         }
       }
     },
@@ -2336,36 +1555,17 @@
     "find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-      "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
-      }
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8="
     },
     "findup-sync": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
-      "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
-      "requires": {
-        "detect-file": "0.1.0",
-        "is-glob": "2.0.1",
-        "micromatch": "2.3.11",
-        "resolve-dir": "0.1.1"
-      }
+      "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI="
     },
     "fined": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/fined/-/fined-1.0.2.tgz",
-      "integrity": "sha1-WyhCS3YNdZiWC374SA3/itNmDpc=",
-      "requires": {
-        "expand-tilde": "1.2.2",
-        "lodash.assignwith": "4.2.0",
-        "lodash.isempty": "4.4.0",
-        "lodash.isplainobject": "4.0.6",
-        "lodash.isstring": "4.0.1",
-        "lodash.pick": "4.4.0",
-        "parse-filepath": "1.0.1"
-      }
+      "integrity": "sha1-WyhCS3YNdZiWC374SA3/itNmDpc="
     },
     "first-chunk-stream": {
       "version": "1.0.0",
@@ -2381,32 +1581,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
-      "dev": true,
-      "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
-      }
+      "dev": true
     },
     "folder-hash": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/folder-hash/-/folder-hash-1.1.1.tgz",
-      "integrity": "sha1-KjhFVBuC1G/NLOAU8oMG6plzhIU=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "when": "3.7.8"
-      }
-    },
-    "follow-redirects": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz",
-      "integrity": "sha1-NLkLqyqRGqNHVx2pDyK9NuzYqRk=",
-      "requires": {
-        "debug": "2.6.8",
-        "stream-consume": "0.1.0"
-      }
+      "integrity": "sha1-KjhFVBuC1G/NLOAU8oMG6plzhIU="
     },
     "for-in": {
       "version": "1.0.2",
@@ -2416,10 +1596,7 @@
     "for-own": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "requires": {
-        "for-in": "1.0.2"
-      }
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4="
     },
     "foreach": {
       "version": "2.0.5",
@@ -2434,12 +1611,7 @@
     "form-data": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.15"
-      }
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE="
     },
     "forwarded": {
       "version": "0.1.0",
@@ -2464,12 +1636,7 @@
     "fs-extra": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
-      "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "3.0.0",
-        "universalify": "0.1.0"
-      }
+      "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -2479,32 +1646,17 @@
     "fstream": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.1"
-      }
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE="
     },
     "ftp-deploy": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ftp-deploy/-/ftp-deploy-1.2.1.tgz",
       "integrity": "sha1-7y5woWhEll+Lq03/2dnrQIs8D38=",
-      "requires": {
-        "async": "2.4.1",
-        "jsftp": "1.5.5",
-        "minimatch": "3.0.3",
-        "read": "1.0.7"
-      },
       "dependencies": {
         "minimatch": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-          "requires": {
-            "brace-expansion": "1.1.7"
-          }
+          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q="
         }
       }
     },
@@ -2512,9 +1664,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ftp-response-parser/-/ftp-response-parser-1.0.1.tgz",
       "integrity": "sha1-O50z+O3V+45HALj3eMRi5bFYH4k=",
-      "requires": {
-        "readable-stream": "1.1.14"
-      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -2524,13 +1673,7 @@
         "readable-stream": {
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk="
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -2554,16 +1697,6 @@
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "requires": {
-        "aproba": "1.1.1",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
-      },
       "dependencies": {
         "object-assign": {
           "version": "4.1.1",
@@ -2575,10 +1708,7 @@
     "gaze": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-      "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
-      "requires": {
-        "globule": "0.1.0"
-      }
+      "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8="
     },
     "get-caller-file": {
       "version": "1.0.2",
@@ -2593,10 +1723,7 @@
     "get-proxy": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.1.0.tgz",
-      "integrity": "sha1-iUhUSRvFkbDxR9euVw9cZ4tyVus=",
-      "requires": {
-        "rc": "1.2.1"
-      }
+      "integrity": "sha1-iUhUSRvFkbDxR9euVw9cZ4tyVus="
     },
     "get-stdin": {
       "version": "4.0.1",
@@ -2612,9 +1739,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "1.0.0"
-      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -2623,70 +1747,30 @@
         }
       }
     },
-    "github": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/github/-/github-9.2.0.tgz",
-      "integrity": "sha1-iohtxA3WNjZwfcr5nfPfJsWfFvw=",
-      "requires": {
-        "follow-redirects": "0.0.7",
-        "https-proxy-agent": "1.0.0",
-        "mime": "1.3.4",
-        "netrc": "0.1.4"
-      }
-    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
-      }
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
     },
     "glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
-      }
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q="
     },
     "glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "requires": {
-        "is-glob": "2.0.1"
-      }
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg="
     },
     "glob-stream": {
       "version": "3.1.18",
       "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
       "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
-      "requires": {
-        "glob": "4.5.3",
-        "glob2base": "0.0.12",
-        "minimatch": "2.0.10",
-        "ordered-read-streams": "0.1.0",
-        "through2": "0.6.5",
-        "unique-stream": "1.0.0"
-      },
       "dependencies": {
         "glob": {
           "version": "4.5.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "2.0.10",
-            "once": "1.4.0"
-          }
+          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8="
         },
         "isarray": {
           "version": "0.0.1",
@@ -2696,21 +1780,12 @@
         "minimatch": {
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "requires": {
-            "brace-expansion": "1.1.7"
-          }
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc="
         },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw="
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -2720,49 +1795,29 @@
         "through2": {
           "version": "0.6.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
-          }
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg="
         }
       }
     },
     "glob-watcher": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
-      "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
-      "requires": {
-        "gaze": "0.5.2"
-      }
+      "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs="
     },
     "glob2base": {
       "version": "0.0.12",
       "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-      "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
-      "requires": {
-        "find-index": "0.1.1"
-      }
+      "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY="
     },
     "global-modules": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
-      "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
-      "requires": {
-        "global-prefix": "0.1.5",
-        "is-windows": "0.2.0"
-      }
+      "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0="
     },
     "global-prefix": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
-      "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
-      "requires": {
-        "homedir-polyfill": "1.0.1",
-        "ini": "1.3.4",
-        "is-windows": "0.2.0",
-        "which": "1.2.14"
-      }
+      "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948="
     },
     "globals": {
       "version": "9.17.0",
@@ -2774,14 +1829,6 @@
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
-      "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      },
       "dependencies": {
         "object-assign": {
           "version": "4.1.1",
@@ -2795,21 +1842,11 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
       "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
-      "requires": {
-        "glob": "3.1.21",
-        "lodash": "1.0.2",
-        "minimatch": "0.2.14"
-      },
       "dependencies": {
         "glob": {
           "version": "3.1.21",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-          "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-          "requires": {
-            "graceful-fs": "1.2.3",
-            "inherits": "1.0.2",
-            "minimatch": "0.2.14"
-          }
+          "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0="
         },
         "graceful-fs": {
           "version": "1.2.3",
@@ -2829,21 +1866,14 @@
         "minimatch": {
           "version": "0.2.14",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-          "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
-          }
+          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo="
         }
       }
     },
     "glogg": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
-      "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
-      "requires": {
-        "sparkles": "1.0.0"
-      }
+      "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U="
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -2859,21 +1889,6 @@
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
       "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
-      "requires": {
-        "archy": "1.0.0",
-        "chalk": "1.1.3",
-        "deprecated": "0.0.1",
-        "gulp-util": "3.0.8",
-        "interpret": "1.0.3",
-        "liftoff": "2.3.0",
-        "minimist": "1.2.0",
-        "orchestrator": "0.3.8",
-        "pretty-hrtime": "1.0.3",
-        "semver": "4.3.6",
-        "tildify": "1.2.0",
-        "v8flags": "2.1.1",
-        "vinyl-fs": "0.3.14"
-      },
       "dependencies": {
         "semver": {
           "version": "4.3.6",
@@ -2886,14 +1901,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/gulp-babel/-/gulp-babel-6.1.2.tgz",
       "integrity": "sha1-fAF25Lo/JExgWIoMSzIKRdGt784=",
-      "requires": {
-        "babel-core": "6.24.1",
-        "gulp-util": "3.0.8",
-        "object-assign": "4.1.1",
-        "replace-ext": "0.0.1",
-        "through2": "2.0.3",
-        "vinyl-sourcemaps-apply": "0.2.1"
-      },
       "dependencies": {
         "object-assign": {
           "version": "4.1.1",
@@ -2906,11 +1913,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/gulp-clean/-/gulp-clean-0.3.2.tgz",
       "integrity": "sha1-o0fUc6zqQBgvk1WHpFGUFnGSgQI=",
-      "requires": {
-        "gulp-util": "2.2.20",
-        "rimraf": "2.6.1",
-        "through2": "0.4.2"
-      },
       "dependencies": {
         "ansi-regex": {
           "version": "0.2.1",
@@ -2925,57 +1927,29 @@
         "chalk": {
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
-          "requires": {
-            "ansi-styles": "1.1.0",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "0.1.0",
-            "strip-ansi": "0.3.0",
-            "supports-color": "0.2.0"
-          }
+          "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ="
         },
         "dateformat": {
           "version": "1.0.12",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-          "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-          "requires": {
-            "get-stdin": "4.0.1",
-            "meow": "3.7.0"
-          }
+          "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk="
         },
         "gulp-util": {
           "version": "2.2.20",
           "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
           "integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
-          "requires": {
-            "chalk": "0.5.1",
-            "dateformat": "1.0.12",
-            "lodash._reinterpolate": "2.4.1",
-            "lodash.template": "2.4.1",
-            "minimist": "0.2.0",
-            "multipipe": "0.1.2",
-            "through2": "0.5.1",
-            "vinyl": "0.2.3"
-          },
           "dependencies": {
             "through2": {
               "version": "0.5.1",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-              "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
-              "requires": {
-                "readable-stream": "1.0.34",
-                "xtend": "3.0.0"
-              }
+              "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac="
             }
           }
         },
         "has-ansi": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-          "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
-          "requires": {
-            "ansi-regex": "0.2.1"
-          }
+          "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4="
         },
         "isarray": {
           "version": "0.0.1",
@@ -2990,45 +1964,22 @@
         "lodash.escape": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
-          "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
-          "requires": {
-            "lodash._escapehtmlchar": "2.4.1",
-            "lodash._reunescapedhtml": "2.4.1",
-            "lodash.keys": "2.4.1"
-          }
+          "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q="
         },
         "lodash.keys": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-          "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-          "requires": {
-            "lodash._isnative": "2.4.1",
-            "lodash._shimkeys": "2.4.1",
-            "lodash.isobject": "2.4.1"
-          }
+          "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc="
         },
         "lodash.template": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
-          "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
-          "requires": {
-            "lodash._escapestringchar": "2.4.1",
-            "lodash._reinterpolate": "2.4.1",
-            "lodash.defaults": "2.4.1",
-            "lodash.escape": "2.4.1",
-            "lodash.keys": "2.4.1",
-            "lodash.templatesettings": "2.4.1",
-            "lodash.values": "2.4.1"
-          }
+          "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0="
         },
         "lodash.templatesettings": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
-          "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
-          "requires": {
-            "lodash._reinterpolate": "2.4.1",
-            "lodash.escape": "2.4.1"
-          }
+          "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk="
         },
         "minimist": {
           "version": "0.2.0",
@@ -3038,13 +1989,7 @@
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw="
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -3054,10 +1999,7 @@
         "strip-ansi": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-          "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
-          "requires": {
-            "ansi-regex": "0.2.1"
-          }
+          "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA="
         },
         "supports-color": {
           "version": "0.2.0",
@@ -3068,28 +2010,18 @@
           "version": "0.4.2",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
           "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
-          "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "2.1.2"
-          },
           "dependencies": {
             "xtend": {
               "version": "2.1.2",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-              "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-              "requires": {
-                "object-keys": "0.4.0"
-              }
+              "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os="
             }
           }
         },
         "vinyl": {
           "version": "0.2.3",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
-          "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
-          "requires": {
-            "clone-stats": "0.0.1"
-          }
+          "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI="
         },
         "xtend": {
           "version": "3.0.0",
@@ -3102,11 +2034,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.1.tgz",
       "integrity": "sha1-Yz0WyV2IUEYorQJmVmPO5aR5M1M=",
-      "requires": {
-        "concat-with-sourcemaps": "1.0.4",
-        "through2": "2.0.3",
-        "vinyl": "2.0.2"
-      },
       "dependencies": {
         "clone-stats": {
           "version": "1.0.0",
@@ -3121,16 +2048,7 @@
         "vinyl": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.2.tgz",
-          "integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw=",
-          "requires": {
-            "clone": "1.0.2",
-            "clone-buffer": "1.0.0",
-            "clone-stats": "1.0.0",
-            "cloneable-readable": "1.0.0",
-            "is-stream": "1.1.0",
-            "remove-trailing-separator": "1.0.1",
-            "replace-ext": "1.0.0"
-          }
+          "integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw="
         }
       }
     },
@@ -3138,14 +2056,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/gulp-htmlmin/-/gulp-htmlmin-3.0.0.tgz",
       "integrity": "sha1-GeqAAtEjHWsfGKEtIPKmand3D7M=",
-      "requires": {
-        "bufferstreams": "1.1.1",
-        "gulp-util": "3.0.8",
-        "html-minifier": "3.5.2",
-        "object-assign": "4.1.1",
-        "readable-stream": "2.2.9",
-        "tryit": "1.0.3"
-      },
       "dependencies": {
         "object-assign": {
           "version": "4.1.1",
@@ -3158,12 +2068,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/gulp-iife/-/gulp-iife-0.3.0.tgz",
       "integrity": "sha1-inSMjpc90MZ06MVznZF9R3NxSFs=",
-      "requires": {
-        "lodash": "3.10.1",
-        "source-map": "0.5.6",
-        "through2": "2.0.3",
-        "vinyl-sourcemaps-apply": "0.2.1"
-      },
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
@@ -3176,31 +2080,16 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/gulp-minify-css/-/gulp-minify-css-1.2.4.tgz",
       "integrity": "sha1-thZJV2Auon+eWtiCJ2ld0gV3jAY=",
-      "requires": {
-        "clean-css": "3.4.26",
-        "gulp-util": "3.0.8",
-        "object-assign": "4.1.1",
-        "readable-stream": "2.2.9",
-        "vinyl-bufferstream": "1.0.1",
-        "vinyl-sourcemaps-apply": "0.2.1"
-      },
       "dependencies": {
         "clean-css": {
           "version": "3.4.26",
           "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.26.tgz",
-          "integrity": "sha1-VTI7NE/zvO5oSi6sgck9+Ppz3us=",
-          "requires": {
-            "commander": "2.8.1",
-            "source-map": "0.4.4"
-          }
+          "integrity": "sha1-VTI7NE/zvO5oSi6sgck9+Ppz3us="
         },
         "commander": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          }
+          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ="
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3210,70 +2099,29 @@
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s="
         }
       }
     },
     "gulp-uglify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-3.0.0.tgz",
-      "integrity": "sha1-DfAzHXKg0wLj434QlIXd3zPG0co=",
-      "requires": {
-        "gulplog": "1.0.0",
-        "has-gulplog": "0.1.0",
-        "lodash": "4.17.4",
-        "make-error-cause": "1.2.2",
-        "through2": "2.0.3",
-        "uglify-js": "3.0.11",
-        "vinyl-sourcemaps-apply": "0.2.1"
-      }
+      "integrity": "sha1-DfAzHXKg0wLj434QlIXd3zPG0co="
     },
     "gulp-util": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
-      "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
-      "requires": {
-        "array-differ": "1.0.0",
-        "array-uniq": "1.0.3",
-        "beeper": "1.1.1",
-        "chalk": "1.1.3",
-        "dateformat": "2.0.0",
-        "fancy-log": "1.3.0",
-        "gulplog": "1.0.0",
-        "has-gulplog": "0.1.0",
-        "lodash._reescape": "3.0.0",
-        "lodash._reevaluate": "3.0.0",
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.template": "3.6.2",
-        "minimist": "1.2.0",
-        "multipipe": "0.1.2",
-        "object-assign": "3.0.0",
-        "replace-ext": "0.0.1",
-        "through2": "2.0.3",
-        "vinyl": "0.5.3"
-      }
+      "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08="
     },
     "gulplog": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-      "requires": {
-        "glogg": "1.0.0"
-      }
+      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U="
     },
     "handlebars": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
       "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
-      "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.27"
-      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -3283,21 +2131,13 @@
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s="
         },
         "uglify-js": {
           "version": "2.8.27",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.27.tgz",
           "integrity": "sha1-R3h/kSsPJC5bmENDvo416V9pTJw=",
           "optional": true,
-          "requires": {
-            "source-map": "0.5.6",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
-          },
           "dependencies": {
             "source-map": {
               "version": "0.5.6",
@@ -3317,35 +2157,22 @@
     "har-validator": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-      "requires": {
-        "ajv": "4.11.8",
-        "har-schema": "1.0.5"
-      }
+      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio="
     },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "requires": {
-        "function-bind": "1.1.1"
-      }
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw=="
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
     },
     "has-binary2": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.2.tgz",
       "integrity": "sha1-6D26SfC5vk0CbSc2U1DZ8D9Uvpg=",
-      "requires": {
-        "isarray": "2.0.1"
-      },
       "dependencies": {
         "isarray": {
           "version": "2.0.1",
@@ -3368,10 +2195,7 @@
     "has-gulplog": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-      "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-      "requires": {
-        "sparkles": "1.0.0"
-      }
+      "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4="
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -3381,13 +2205,7 @@
     "hawk": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
-      }
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
     },
     "he": {
       "version": "1.1.1",
@@ -3402,19 +2220,12 @@
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg="
     },
     "homedir-polyfill": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
-      "requires": {
-        "parse-passwd": "1.0.0"
-      }
+      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw="
     },
     "hosted-git-info": {
       "version": "2.4.2",
@@ -3424,73 +2235,50 @@
     "html-minifier": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.2.tgz",
-      "integrity": "sha1-1zvD/0SJQkCIGM5gm/P7DqfvTrc=",
-      "requires": {
-        "camel-case": "3.0.0",
-        "clean-css": "4.1.3",
-        "commander": "2.9.0",
-        "he": "1.1.1",
-        "ncname": "1.0.0",
-        "param-case": "2.1.1",
-        "relateurl": "0.2.7",
-        "uglify-js": "3.0.11"
-      }
+      "integrity": "sha1-1zvD/0SJQkCIGM5gm/P7DqfvTrc="
     },
     "http-errors": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
-      "integrity": "sha1-X4uO2YrKVFZWv1cplzh/kEpyIlc=",
-      "requires": {
-        "depd": "1.1.0",
-        "inherits": "2.0.3",
-        "setprototypeof": "1.0.3",
-        "statuses": "1.3.1"
+      "integrity": "sha1-X4uO2YrKVFZWv1cplzh/kEpyIlc="
+    },
+    "http-proxy-agent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+      "dependencies": {
+        "agent-base": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+          "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg=="
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g=="
+        }
       }
     },
     "http-signature": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "requires": {
-        "assert-plus": "0.2.0",
-        "jsprim": "1.4.0",
-        "sshpk": "1.13.0"
-      }
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
     },
     "httpntlm": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.6.1.tgz",
-      "integrity": "sha1-rQFScUOi6Hc8+uapb1hla7UqNLI=",
-      "requires": {
-        "httpreq": "0.4.23",
-        "underscore": "1.7.0"
-      }
+      "integrity": "sha1-rQFScUOi6Hc8+uapb1hla7UqNLI="
     },
     "httpreq": {
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.4.23.tgz",
       "integrity": "sha1-D0YP4MeBApvK1/R8rQjebMETAhI="
     },
-    "https-proxy-agent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
-      "requires": {
-        "agent-base": "2.1.1",
-        "debug": "2.6.8",
-        "extend": "3.0.1"
-      }
-    },
     "husky": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
       "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
       "dev": true,
-      "requires": {
-        "is-ci": "1.1.0",
-        "normalize-path": "1.0.0",
-        "strip-indent": "2.0.0"
-      },
       "dependencies": {
         "normalize-path": {
           "version": "1.0.0",
@@ -3536,10 +2324,7 @@
     "indent-string": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "requires": {
-        "repeating": "2.0.1"
-      }
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA="
     },
     "indexof": {
       "version": "0.0.1",
@@ -3554,11 +2339,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
-      }
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
     },
     "inherits": {
       "version": "2.0.3",
@@ -3575,22 +2356,6 @@
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
-      "requires": {
-        "ansi-escapes": "3.1.0",
-        "chalk": "2.4.1",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "2.2.0",
-        "figures": "2.0.0",
-        "lodash": "4.17.4",
-        "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rx-lite": "4.0.8",
-        "rx-lite-aggregates": "4.0.8",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "through": "2.3.8"
-      },
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
@@ -3602,21 +2367,13 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.0"
-          }
+          "dev": true
         },
         "chalk": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
-          }
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -3628,29 +2385,19 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
+          "dev": true
         },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
+          "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-          "dev": true,
-          "requires": {
-            "has-flag": "3.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -3662,10 +2409,7 @@
     "invariant": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "requires": {
-        "loose-envify": "1.3.1"
-      }
+      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A="
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -3680,11 +2424,7 @@
     "is-absolute": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
-      "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
-      "requires": {
-        "is-relative": "0.2.1",
-        "is-windows": "0.2.0"
-      }
+      "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -3699,10 +2439,7 @@
     "is-builtin-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "requires": {
-        "builtin-modules": "1.1.1"
-      }
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74="
     },
     "is-callable": {
       "version": "1.1.3",
@@ -3713,10 +2450,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
       "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
-      "dev": true,
-      "requires": {
-        "ci-info": "1.1.3"
-      }
+      "dev": true
     },
     "is-date-object": {
       "version": "1.0.1",
@@ -3731,10 +2465,7 @@
     "is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "requires": {
-        "is-primitive": "2.0.0"
-      }
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ="
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -3749,34 +2480,22 @@
     "is-finite": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko="
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
     },
     "is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "requires": {
-        "is-extglob": "1.0.0"
-      }
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM="
     },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "requires": {
-        "kind-of": "3.2.2"
-      }
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8="
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -3788,19 +2507,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
-      "dev": true,
-      "requires": {
-        "is-path-inside": "1.0.1"
-      }
+      "dev": true
     },
     "is-path-inside": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "1.0.2"
-      }
+      "dev": true
     },
     "is-posix-bracket": {
       "version": "0.1.1",
@@ -3826,18 +2539,12 @@
     "is-regex": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "requires": {
-        "has": "1.0.3"
-      }
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE="
     },
     "is-relative": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
-      "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
-      "requires": {
-        "is-unc-path": "0.1.2"
-      }
+      "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU="
     },
     "is-resolvable": {
       "version": "1.1.0",
@@ -3868,10 +2575,7 @@
     "is-unc-path": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
-      "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
-      "requires": {
-        "unc-path-regex": "0.1.2"
-      }
+      "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk="
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -3896,10 +2600,7 @@
     "isobject": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "requires": {
-        "isarray": "1.0.0"
-      }
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk="
     },
     "isstream": {
       "version": "0.1.2",
@@ -3915,10 +2616,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
       "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-      "optional": true,
-      "requires": {
-        "jsbn": "0.1.1"
-      }
+      "optional": true
     },
     "js-base64": {
       "version": "2.1.9",
@@ -3934,11 +2632,7 @@
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
-      "dev": true,
-      "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.0"
-      }
+      "dev": true
     },
     "jsbn": {
       "version": "0.1.1",
@@ -3954,15 +2648,7 @@
     "jsftp": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/jsftp/-/jsftp-1.5.5.tgz",
-      "integrity": "sha1-PQNFaaWCIcj/xn0Ihoj1nS6ZXO4=",
-      "requires": {
-        "debug": "2.6.8",
-        "ftp-response-parser": "1.0.1",
-        "once": "1.4.0",
-        "parse-listing": "1.1.3",
-        "stream-combiner": "0.2.2",
-        "unorm": "1.4.1"
-      }
+      "integrity": "sha1-PQNFaaWCIcj/xn0Ihoj1nS6ZXO4="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -3978,10 +2664,7 @@
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "requires": {
-        "jsonify": "0.0.0"
-      }
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4002,19 +2685,12 @@
     "jsonapi-serializer": {
       "version": "3.5.5",
       "resolved": "https://registry.npmjs.org/jsonapi-serializer/-/jsonapi-serializer-3.5.5.tgz",
-      "integrity": "sha1-vDRbvW6U8BqQ9bLUlCr7tjchIiI=",
-      "requires": {
-        "inflected": "1.1.7",
-        "lodash": "4.17.4"
-      }
+      "integrity": "sha1-vDRbvW6U8BqQ9bLUlCr7tjchIiI="
     },
     "jsonfile": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.0.tgz",
-      "integrity": "sha1-kufHRE5f/V+jLmqa6LhQNN+DR9A=",
-      "requires": {
-        "graceful-fs": "4.1.11"
-      }
+      "integrity": "sha1-kufHRE5f/V+jLmqa6LhQNN+DR9A="
     },
     "jsonify": {
       "version": "0.0.0",
@@ -4025,12 +2701,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
       "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.0.2",
-        "json-schema": "0.2.3",
-        "verror": "1.3.6"
-      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -4042,10 +2712,7 @@
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "requires": {
-        "is-buffer": "1.1.5"
-      }
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ="
     },
     "lazy-cache": {
       "version": "1.0.4",
@@ -4056,64 +2723,33 @@
     "lazystream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
-      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
-      "requires": {
-        "readable-stream": "2.2.9"
-      }
+      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ="
     },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "requires": {
-        "invert-kv": "1.0.0"
-      }
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU="
     },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
-      }
+      "dev": true
     },
     "liftoff": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
-      "integrity": "sha1-qY8v9nGD2Lp8+soQVIvX/wVQs4U=",
-      "requires": {
-        "extend": "3.0.1",
-        "findup-sync": "0.4.3",
-        "fined": "1.0.2",
-        "flagged-respawn": "0.3.2",
-        "lodash.isplainobject": "4.0.6",
-        "lodash.isstring": "4.0.1",
-        "lodash.mapvalues": "4.6.0",
-        "rechoir": "0.6.2",
-        "resolve": "1.3.3"
-      }
+      "integrity": "sha1-qY8v9nGD2Lp8+soQVIvX/wVQs4U="
     },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
-      },
       "dependencies": {
         "strip-bom": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4="
         }
       }
     },
@@ -4140,10 +2776,7 @@
     "lodash._escapehtmlchar": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
-      "integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0=",
-      "requires": {
-        "lodash._htmlescapes": "2.4.1"
-      }
+      "integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0="
     },
     "lodash._escapestringchar": {
       "version": "2.4.1",
@@ -4194,20 +2827,11 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
       "integrity": "sha1-dHxPxAED6zu4oJduVx96JlnpO6c=",
-      "requires": {
-        "lodash._htmlescapes": "2.4.1",
-        "lodash.keys": "2.4.1"
-      },
       "dependencies": {
         "lodash.keys": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-          "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-          "requires": {
-            "lodash._isnative": "2.4.1",
-            "lodash._shimkeys": "2.4.1",
-            "lodash.isobject": "2.4.1"
-          }
+          "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc="
         }
       }
     },
@@ -4219,10 +2843,7 @@
     "lodash._shimkeys": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
-      "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
-      "requires": {
-        "lodash._objecttypes": "2.4.1"
-      }
+      "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM="
     },
     "lodash.assign": {
       "version": "4.2.0",
@@ -4248,30 +2869,18 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
       "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
-      "requires": {
-        "lodash._objecttypes": "2.4.1",
-        "lodash.keys": "2.4.1"
-      },
       "dependencies": {
         "lodash.keys": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-          "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-          "requires": {
-            "lodash._isnative": "2.4.1",
-            "lodash._shimkeys": "2.4.1",
-            "lodash.isobject": "2.4.1"
-          }
+          "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc="
         }
       }
     },
     "lodash.escape": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-      "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-      "requires": {
-        "lodash._root": "3.0.1"
-      }
+      "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg="
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -4291,10 +2900,7 @@
     "lodash.isobject": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-      "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
-      "requires": {
-        "lodash._objecttypes": "2.4.1"
-      }
+      "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
@@ -4309,12 +2915,7 @@
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
-      }
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo="
     },
     "lodash.mapvalues": {
       "version": "4.6.0",
@@ -4339,45 +2940,22 @@
     "lodash.template": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-      "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-      "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash._basetostring": "3.0.1",
-        "lodash._basevalues": "3.0.0",
-        "lodash._isiterateecall": "3.0.9",
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.escape": "3.2.0",
-        "lodash.keys": "3.1.2",
-        "lodash.restparam": "3.6.1",
-        "lodash.templatesettings": "3.1.1"
-      }
+      "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8="
     },
     "lodash.templatesettings": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-      "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-      "requires": {
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.escape": "3.2.0"
-      }
+      "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU="
     },
     "lodash.values": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
       "integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
-      "requires": {
-        "lodash.keys": "2.4.1"
-      },
       "dependencies": {
         "lodash.keys": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-          "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-          "requires": {
-            "lodash._isnative": "2.4.1",
-            "lodash._shimkeys": "2.4.1",
-            "lodash.isobject": "2.4.1"
-          }
+          "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc="
         }
       }
     },
@@ -4389,19 +2967,12 @@
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "requires": {
-        "js-tokens": "3.0.1"
-      }
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg="
     },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
-      }
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8="
     },
     "lower-case": {
       "version": "1.1.4",
@@ -4423,16 +2994,15 @@
       "resolved": "https://registry.npmjs.org/lsmod/-/lsmod-1.0.0.tgz",
       "integrity": "sha1-mgD3bco26yP6BTUK/htYXUKZ5ks="
     },
+    "macos-release": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-1.1.0.tgz",
+      "integrity": "sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA=="
+    },
     "mailparser": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-0.6.2.tgz",
-      "integrity": "sha1-A8SGA5vfTfbNO2rcqqxBB9/bwGg=",
-      "requires": {
-        "encoding": "0.1.12",
-        "mime": "1.3.4",
-        "mimelib": "0.3.0",
-        "uue": "3.1.0"
-      }
+      "integrity": "sha1-A8SGA5vfTfbNO2rcqqxBB9/bwGg="
     },
     "make-error": {
       "version": "1.3.0",
@@ -4442,10 +3012,7 @@
     "make-error-cause": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/make-error-cause/-/make-error-cause-1.2.2.tgz",
-      "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
-      "requires": {
-        "make-error": "1.3.0"
-      }
+      "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0="
     },
     "map-cache": {
       "version": "0.2.2",
@@ -4466,18 +3033,6 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-      "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.3.8",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
-      },
       "dependencies": {
         "object-assign": {
           "version": "4.1.1",
@@ -4499,22 +3054,7 @@
     "micromatch": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.3"
-      }
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU="
     },
     "mime": {
       "version": "1.3.4",
@@ -4529,19 +3069,12 @@
     "mime-types": {
       "version": "2.1.15",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-      "requires": {
-        "mime-db": "1.27.0"
-      }
+      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0="
     },
     "mimelib": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/mimelib/-/mimelib-0.3.0.tgz",
-      "integrity": "sha1-SxbUtDVAPa9pK8IniQxxZf896JQ=",
-      "requires": {
-        "addressparser": "1.0.1",
-        "encoding": "0.1.12"
-      }
+      "integrity": "sha1-SxbUtDVAPa9pK8IniQxxZf896JQ="
     },
     "mimic-fn": {
       "version": "1.2.0",
@@ -4552,10 +3085,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "requires": {
-        "brace-expansion": "1.1.7"
-      }
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
     },
     "minimist": {
       "version": "1.2.0",
@@ -4566,9 +3096,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "requires": {
-        "minimist": "0.0.8"
-      },
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
@@ -4595,10 +3122,7 @@
     "multipipe": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-      "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-      "requires": {
-        "duplexer2": "0.0.2"
-      }
+      "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -4624,48 +3148,27 @@
     "ncname": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
-      "integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
-      "requires": {
-        "xml-char-classes": "1.0.0"
-      }
+      "integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw="
     },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
-    "netrc": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/netrc/-/netrc-0.1.4.tgz",
-      "integrity": "sha1-a+lPysqNd63gqWcNxGCRTJRHJEQ="
-    },
     "no-case": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.1.tgz",
-      "integrity": "sha1-euuhxzpSGEJlVUt9wDuvcg34AIE=",
-      "requires": {
-        "lower-case": "1.1.4"
-      }
+      "integrity": "sha1-euuhxzpSGEJlVUt9wDuvcg34AIE="
+    },
+    "node-fetch": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
+      "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA=="
     },
     "node-gyp": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
       "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
-      "requires": {
-        "fstream": "1.0.11",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "npmlog": "4.1.0",
-        "osenv": "0.1.4",
-        "request": "2.81.0",
-        "rimraf": "2.6.1",
-        "semver": "5.3.0",
-        "tar": "2.2.1",
-        "which": "1.2.14"
-      },
       "dependencies": {
         "semver": {
           "version": "5.3.0",
@@ -4678,44 +3181,16 @@
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz",
       "integrity": "sha1-0JydEXlkEjnRuX/8YjH9zsU+FWg=",
-      "requires": {
-        "async-foreach": "0.1.3",
-        "chalk": "1.1.3",
-        "cross-spawn": "3.0.1",
-        "gaze": "1.1.2",
-        "get-stdin": "4.0.1",
-        "glob": "7.1.2",
-        "in-publish": "2.0.0",
-        "lodash.assign": "4.2.0",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.mergewith": "4.6.0",
-        "meow": "3.7.0",
-        "mkdirp": "0.5.1",
-        "nan": "2.6.2",
-        "node-gyp": "3.6.2",
-        "npmlog": "4.1.0",
-        "request": "2.81.0",
-        "sass-graph": "2.2.4",
-        "stdout-stream": "1.4.0"
-      },
       "dependencies": {
         "gaze": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
-          "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
-          "requires": {
-            "globule": "1.1.0"
-          }
+          "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU="
         },
         "globule": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/globule/-/globule-1.1.0.tgz",
-          "integrity": "sha1-xJNS5NwYPYWJPuglOF65lLtt9F8=",
-          "requires": {
-            "glob": "7.1.2",
-            "lodash": "4.16.6",
-            "minimatch": "3.0.4"
-          }
+          "integrity": "sha1-xJNS5NwYPYWJPuglOF65lLtt9F8="
         },
         "lodash": {
           "version": "4.16.6",
@@ -4742,20 +3217,12 @@
     "nodemailer-shared": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/nodemailer-shared/-/nodemailer-shared-1.1.0.tgz",
-      "integrity": "sha1-z1mU4v0mjQD1zw+nZ6CBae2wfsA=",
-      "requires": {
-        "nodemailer-fetch": "1.6.0"
-      }
+      "integrity": "sha1-z1mU4v0mjQD1zw+nZ6CBae2wfsA="
     },
     "nodemailer-smtp-transport": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/nodemailer-smtp-transport/-/nodemailer-smtp-transport-2.7.4.tgz",
-      "integrity": "sha1-DYmvAZoUSkgP2OzJmZfZ+DjxNoU=",
-      "requires": {
-        "nodemailer-shared": "1.1.0",
-        "nodemailer-wellknown": "0.1.10",
-        "smtp-connection": "2.12.0"
-      }
+      "integrity": "sha1-DYmvAZoUSkgP2OzJmZfZ+DjxNoU="
     },
     "nodemailer-wellknown": {
       "version": "0.1.10",
@@ -4765,161 +3232,23 @@
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "requires": {
-        "abbrev": "1.1.0"
-      }
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k="
     },
     "normalize-package-data": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-      "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
-      "requires": {
-        "hosted-git-info": "2.4.2",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.0.3",
-        "validate-npm-package-license": "3.0.1"
-      }
+      "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs="
     },
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "requires": {
-        "remove-trailing-separator": "1.0.1"
-      }
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk="
     },
     "npm": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/npm/-/npm-5.6.0.tgz",
       "integrity": "sha512-mt839mCsI5hzdBJLf1iRBwt610P35iUfvqLVuL7VFdanUwRBAmGtbsjdGIuzegplR95xx+fTHE0vBMuMJp1sLQ==",
-      "requires": {
-        "JSONStream": "1.3.1",
-        "abbrev": "1.1.1",
-        "ansi-regex": "3.0.0",
-        "ansicolors": "0.3.2",
-        "ansistyles": "0.1.3",
-        "aproba": "1.2.0",
-        "archy": "1.0.0",
-        "bin-links": "1.1.0",
-        "bluebird": "3.5.1",
-        "cacache": "10.0.1",
-        "call-limit": "1.1.0",
-        "chownr": "1.0.1",
-        "cli-table2": "0.2.0",
-        "cmd-shim": "2.0.2",
-        "columnify": "1.5.4",
-        "config-chain": "1.1.11",
-        "debuglog": "1.0.1",
-        "detect-indent": "5.0.0",
-        "dezalgo": "1.0.3",
-        "editor": "1.0.0",
-        "find-npm-prefix": "1.0.1",
-        "fs-vacuum": "1.2.10",
-        "fs-write-stream-atomic": "1.0.10",
-        "gentle-fs": "2.0.1",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "has-unicode": "2.0.1",
-        "hosted-git-info": "2.5.0",
-        "iferr": "0.1.5",
-        "imurmurhash": "0.1.4",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "ini": "1.3.4",
-        "init-package-json": "1.10.1",
-        "is-cidr": "1.0.0",
-        "lazy-property": "1.0.0",
-        "libnpx": "9.7.1",
-        "lockfile": "1.0.3",
-        "lodash._baseindexof": "3.1.0",
-        "lodash._baseuniq": "4.6.0",
-        "lodash._bindcallback": "3.0.1",
-        "lodash._cacheindexof": "3.0.2",
-        "lodash._createcache": "3.1.2",
-        "lodash._getnative": "3.9.1",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.restparam": "3.6.1",
-        "lodash.union": "4.6.0",
-        "lodash.uniq": "4.5.0",
-        "lodash.without": "4.4.0",
-        "lru-cache": "4.1.1",
-        "meant": "1.0.1",
-        "mississippi": "1.3.0",
-        "mkdirp": "0.5.1",
-        "move-concurrently": "1.0.1",
-        "nopt": "4.0.1",
-        "normalize-package-data": "2.4.0",
-        "npm-cache-filename": "1.0.2",
-        "npm-install-checks": "3.0.0",
-        "npm-lifecycle": "2.0.0",
-        "npm-package-arg": "6.0.0",
-        "npm-packlist": "1.1.10",
-        "npm-profile": "2.0.5",
-        "npm-registry-client": "8.5.0",
-        "npm-user-validate": "1.0.0",
-        "npmlog": "4.1.2",
-        "once": "1.4.0",
-        "opener": "1.4.3",
-        "osenv": "0.1.4",
-        "pacote": "7.0.2",
-        "path-is-inside": "1.0.2",
-        "promise-inflight": "1.0.1",
-        "qrcode-terminal": "0.11.0",
-        "query-string": "5.0.1",
-        "qw": "1.0.1",
-        "read": "1.0.7",
-        "read-cmd-shim": "1.0.1",
-        "read-installed": "4.0.3",
-        "read-package-json": "2.0.12",
-        "read-package-tree": "5.1.6",
-        "readable-stream": "2.3.3",
-        "readdir-scoped-modules": "1.0.2",
-        "request": "2.83.0",
-        "retry": "0.10.1",
-        "rimraf": "2.6.2",
-        "safe-buffer": "5.1.1",
-        "semver": "5.4.1",
-        "sha": "2.0.1",
-        "slide": "1.1.6",
-        "sorted-object": "2.0.1",
-        "sorted-union-stream": "2.1.3",
-        "ssri": "5.0.0",
-        "strip-ansi": "4.0.0",
-        "tar": "4.0.2",
-        "text-table": "0.2.0",
-        "uid-number": "0.0.6",
-        "umask": "1.1.0",
-        "unique-filename": "1.1.0",
-        "unpipe": "1.0.0",
-        "update-notifier": "2.3.0",
-        "uuid": "3.1.0",
-        "validate-npm-package-license": "3.0.1",
-        "validate-npm-package-name": "3.0.0",
-        "which": "1.3.0",
-        "worker-farm": "1.5.1",
-        "wrappy": "1.0.2",
-        "write-file-atomic": "2.1.0"
-      },
       "dependencies": {
-        "JSONStream": {
-          "version": "1.3.1",
-          "bundled": true,
-          "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
-          },
-          "dependencies": {
-            "jsonparse": {
-              "version": "1.3.1",
-              "bundled": true
-            },
-            "through": {
-              "version": "2.3.8",
-              "bundled": true
-            }
-          }
-        },
         "abbrev": {
           "version": "1.1.1",
           "bundled": true
@@ -4946,15 +3275,7 @@
         },
         "bin-links": {
           "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "bluebird": "3.5.1",
-            "cmd-shim": "2.0.2",
-            "fs-write-stream-atomic": "1.0.10",
-            "gentle-fs": "2.0.1",
-            "graceful-fs": "4.1.11",
-            "slide": "1.1.6"
-          }
+          "bundled": true
         },
         "bluebird": {
           "version": "3.5.1",
@@ -4963,28 +3284,10 @@
         "cacache": {
           "version": "10.0.1",
           "bundled": true,
-          "requires": {
-            "bluebird": "3.5.1",
-            "chownr": "1.0.1",
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "lru-cache": "4.1.1",
-            "mississippi": "1.3.0",
-            "mkdirp": "0.5.1",
-            "move-concurrently": "1.0.1",
-            "promise-inflight": "1.0.1",
-            "rimraf": "2.6.2",
-            "ssri": "5.0.0",
-            "unique-filename": "1.1.0",
-            "y18n": "3.2.1"
-          },
           "dependencies": {
             "ssri": {
               "version": "5.0.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
+              "bundled": true
             },
             "y18n": {
               "version": "3.2.1",
@@ -5003,11 +3306,6 @@
         "cli-table2": {
           "version": "0.2.0",
           "bundled": true,
-          "requires": {
-            "colors": "1.1.2",
-            "lodash": "3.10.1",
-            "string-width": "1.0.2"
-          },
           "dependencies": {
             "colors": {
               "version": "1.1.2",
@@ -5021,11 +3319,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
-              },
               "dependencies": {
                 "code-point-at": {
                   "version": "1.1.0",
@@ -5034,9 +3327,6 @@
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
                   "bundled": true,
-                  "requires": {
-                    "number-is-nan": "1.0.1"
-                  },
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.1",
@@ -5047,9 +3337,6 @@
                 "strip-ansi": {
                   "version": "3.0.1",
                   "bundled": true,
-                  "requires": {
-                    "ansi-regex": "2.1.1"
-                  },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
@@ -5063,26 +3350,15 @@
         },
         "cmd-shim": {
           "version": "2.0.2",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "mkdirp": "0.5.1"
-          }
+          "bundled": true
         },
         "columnify": {
           "version": "1.5.4",
           "bundled": true,
-          "requires": {
-            "strip-ansi": "3.0.1",
-            "wcwidth": "1.0.1"
-          },
           "dependencies": {
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.1.1",
@@ -5093,16 +3369,10 @@
             "wcwidth": {
               "version": "1.0.1",
               "bundled": true,
-              "requires": {
-                "defaults": "1.0.3"
-              },
               "dependencies": {
                 "defaults": {
                   "version": "1.0.3",
                   "bundled": true,
-                  "requires": {
-                    "clone": "1.0.2"
-                  },
                   "dependencies": {
                     "clone": {
                       "version": "1.0.2",
@@ -5117,10 +3387,6 @@
         "config-chain": {
           "version": "1.1.11",
           "bundled": true,
-          "requires": {
-            "ini": "1.3.4",
-            "proto-list": "1.2.4"
-          },
           "dependencies": {
             "proto-list": {
               "version": "1.2.4",
@@ -5139,10 +3405,6 @@
         "dezalgo": {
           "version": "1.0.3",
           "bundled": true,
-          "requires": {
-            "asap": "2.0.5",
-            "wrappy": "1.0.2"
-          },
           "dependencies": {
             "asap": {
               "version": "2.0.5",
@@ -5160,48 +3422,19 @@
         },
         "fs-vacuum": {
           "version": "1.2.10",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "path-is-inside": "1.0.2",
-            "rimraf": "2.6.2"
-          }
+          "bundled": true
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "iferr": "0.1.5",
-            "imurmurhash": "0.1.4",
-            "readable-stream": "2.3.3"
-          }
+          "bundled": true
         },
         "gentle-fs": {
           "version": "2.0.1",
-          "bundled": true,
-          "requires": {
-            "aproba": "1.2.0",
-            "fs-vacuum": "1.2.10",
-            "graceful-fs": "4.1.11",
-            "iferr": "0.1.5",
-            "mkdirp": "0.5.1",
-            "path-is-inside": "1.0.2",
-            "read-cmd-shim": "1.0.1",
-            "slide": "1.1.6"
-          }
+          "bundled": true
         },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          },
           "dependencies": {
             "fs.realpath": {
               "version": "1.0.0",
@@ -5210,17 +3443,10 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
                   "bundled": true,
-                  "requires": {
-                    "balanced-match": "1.0.0",
-                    "concat-map": "0.0.1"
-                  },
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
@@ -5262,11 +3488,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
+          "bundled": true
         },
         "inherits": {
           "version": "2.0.3",
@@ -5279,45 +3501,37 @@
         "init-package-json": {
           "version": "1.10.1",
           "bundled": true,
-          "requires": {
-            "glob": "7.1.2",
-            "npm-package-arg": "5.1.2",
-            "promzard": "0.3.0",
-            "read": "1.0.7",
-            "read-package-json": "2.0.12",
-            "semver": "5.4.1",
-            "validate-npm-package-license": "3.0.1",
-            "validate-npm-package-name": "3.0.0"
-          },
           "dependencies": {
             "npm-package-arg": {
               "version": "5.1.2",
-              "bundled": true,
-              "requires": {
-                "hosted-git-info": "2.5.0",
-                "osenv": "0.1.4",
-                "semver": "5.4.1",
-                "validate-npm-package-name": "3.0.0"
-              }
+              "bundled": true
             },
             "promzard": {
               "version": "0.3.0",
-              "bundled": true,
-              "requires": {
-                "read": "1.0.7"
-              }
+              "bundled": true
             }
           }
         },
         "is-cidr": {
           "version": "1.0.0",
           "bundled": true,
-          "requires": {
-            "cidr-regex": "1.0.6"
-          },
           "dependencies": {
             "cidr-regex": {
               "version": "1.0.6",
+              "bundled": true
+            }
+          }
+        },
+        "JSONStream": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dependencies": {
+            "jsonparse": {
+              "version": "1.3.1",
+              "bundled": true
+            },
+            "through": {
+              "version": "2.3.8",
               "bundled": true
             }
           }
@@ -5329,16 +3543,6 @@
         "libnpx": {
           "version": "9.7.1",
           "bundled": true,
-          "requires": {
-            "dotenv": "4.0.0",
-            "npm-package-arg": "5.1.2",
-            "rimraf": "2.6.2",
-            "safe-buffer": "5.1.1",
-            "update-notifier": "2.3.0",
-            "which": "1.3.0",
-            "y18n": "3.2.1",
-            "yargs": "8.0.2"
-          },
           "dependencies": {
             "dotenv": {
               "version": "4.0.0",
@@ -5346,13 +3550,7 @@
             },
             "npm-package-arg": {
               "version": "5.1.2",
-              "bundled": true,
-              "requires": {
-                "hosted-git-info": "2.5.0",
-                "osenv": "0.1.4",
-                "semver": "5.4.1",
-                "validate-npm-package-name": "3.0.0"
-              }
+              "bundled": true
             },
             "y18n": {
               "version": "3.2.1",
@@ -5361,21 +3559,6 @@
             "yargs": {
               "version": "8.0.2",
               "bundled": true,
-              "requires": {
-                "camelcase": "4.1.0",
-                "cliui": "3.2.0",
-                "decamelize": "1.2.0",
-                "get-caller-file": "1.0.2",
-                "os-locale": "2.1.0",
-                "read-pkg-up": "2.0.0",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "2.1.1",
-                "which-module": "2.0.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "7.0.0"
-              },
               "dependencies": {
                 "camelcase": {
                   "version": "4.1.0",
@@ -5384,20 +3567,10 @@
                 "cliui": {
                   "version": "3.2.0",
                   "bundled": true,
-                  "requires": {
-                    "string-width": "1.0.2",
-                    "strip-ansi": "3.0.1",
-                    "wrap-ansi": "2.1.0"
-                  },
                   "dependencies": {
                     "string-width": {
                       "version": "1.0.2",
                       "bundled": true,
-                      "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
-                      },
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.1.0",
@@ -5406,9 +3579,6 @@
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
                           "bundled": true,
-                          "requires": {
-                            "number-is-nan": "1.0.1"
-                          },
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
@@ -5421,9 +3591,6 @@
                     "strip-ansi": {
                       "version": "3.0.1",
                       "bundled": true,
-                      "requires": {
-                        "ansi-regex": "2.1.1"
-                      },
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.1.1",
@@ -5433,11 +3600,7 @@
                     },
                     "wrap-ansi": {
                       "version": "2.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1"
-                      }
+                      "bundled": true
                     }
                   }
                 },
@@ -5452,40 +3615,18 @@
                 "os-locale": {
                   "version": "2.1.0",
                   "bundled": true,
-                  "requires": {
-                    "execa": "0.7.0",
-                    "lcid": "1.0.0",
-                    "mem": "1.1.0"
-                  },
                   "dependencies": {
                     "execa": {
                       "version": "0.7.0",
                       "bundled": true,
-                      "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
-                      },
                       "dependencies": {
                         "cross-spawn": {
                           "version": "5.1.0",
                           "bundled": true,
-                          "requires": {
-                            "lru-cache": "4.1.1",
-                            "shebang-command": "1.2.0",
-                            "which": "1.3.0"
-                          },
                           "dependencies": {
                             "shebang-command": {
                               "version": "1.2.0",
                               "bundled": true,
-                              "requires": {
-                                "shebang-regex": "1.0.0"
-                              },
                               "dependencies": {
                                 "shebang-regex": {
                                   "version": "1.0.0",
@@ -5506,9 +3647,6 @@
                         "npm-run-path": {
                           "version": "2.0.2",
                           "bundled": true,
-                          "requires": {
-                            "path-key": "2.0.1"
-                          },
                           "dependencies": {
                             "path-key": {
                               "version": "2.0.1",
@@ -5533,9 +3671,6 @@
                     "lcid": {
                       "version": "1.0.0",
                       "bundled": true,
-                      "requires": {
-                        "invert-kv": "1.0.0"
-                      },
                       "dependencies": {
                         "invert-kv": {
                           "version": "1.0.0",
@@ -5546,9 +3681,6 @@
                     "mem": {
                       "version": "1.1.0",
                       "bundled": true,
-                      "requires": {
-                        "mimic-fn": "1.1.0"
-                      },
                       "dependencies": {
                         "mimic-fn": {
                           "version": "1.1.0",
@@ -5561,32 +3693,18 @@
                 "read-pkg-up": {
                   "version": "2.0.0",
                   "bundled": true,
-                  "requires": {
-                    "find-up": "2.1.0",
-                    "read-pkg": "2.0.0"
-                  },
                   "dependencies": {
                     "find-up": {
                       "version": "2.1.0",
                       "bundled": true,
-                      "requires": {
-                        "locate-path": "2.0.0"
-                      },
                       "dependencies": {
                         "locate-path": {
                           "version": "2.0.0",
                           "bundled": true,
-                          "requires": {
-                            "p-locate": "2.0.0",
-                            "path-exists": "3.0.0"
-                          },
                           "dependencies": {
                             "p-locate": {
                               "version": "2.0.0",
                               "bundled": true,
-                              "requires": {
-                                "p-limit": "1.1.0"
-                              },
                               "dependencies": {
                                 "p-limit": {
                                   "version": "1.1.0",
@@ -5605,35 +3723,18 @@
                     "read-pkg": {
                       "version": "2.0.0",
                       "bundled": true,
-                      "requires": {
-                        "load-json-file": "2.0.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "2.0.0"
-                      },
                       "dependencies": {
                         "load-json-file": {
                           "version": "2.0.0",
                           "bundled": true,
-                          "requires": {
-                            "graceful-fs": "4.1.11",
-                            "parse-json": "2.2.0",
-                            "pify": "2.3.0",
-                            "strip-bom": "3.0.0"
-                          },
                           "dependencies": {
                             "parse-json": {
                               "version": "2.2.0",
                               "bundled": true,
-                              "requires": {
-                                "error-ex": "1.3.1"
-                              },
                               "dependencies": {
                                 "error-ex": {
                                   "version": "1.3.1",
                                   "bundled": true,
-                                  "requires": {
-                                    "is-arrayish": "0.2.1"
-                                  },
                                   "dependencies": {
                                     "is-arrayish": {
                                       "version": "0.2.1",
@@ -5656,9 +3757,6 @@
                         "path-type": {
                           "version": "2.0.0",
                           "bundled": true,
-                          "requires": {
-                            "pify": "2.3.0"
-                          },
                           "dependencies": {
                             "pify": {
                               "version": "2.3.0",
@@ -5685,10 +3783,6 @@
                 "string-width": {
                   "version": "2.1.1",
                   "bundled": true,
-                  "requires": {
-                    "is-fullwidth-code-point": "2.0.0",
-                    "strip-ansi": "4.0.0"
-                  },
                   "dependencies": {
                     "is-fullwidth-code-point": {
                       "version": "2.0.0",
@@ -5702,10 +3796,7 @@
                 },
                 "yargs-parser": {
                   "version": "7.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "camelcase": "4.1.0"
-                  }
+                  "bundled": true
                 }
               }
             }
@@ -5722,10 +3813,6 @@
         "lodash._baseuniq": {
           "version": "4.6.0",
           "bundled": true,
-          "requires": {
-            "lodash._createset": "4.0.3",
-            "lodash._root": "3.0.1"
-          },
           "dependencies": {
             "lodash._createset": {
               "version": "4.0.3",
@@ -5747,10 +3834,7 @@
         },
         "lodash._createcache": {
           "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "lodash._getnative": "3.9.1"
-          }
+          "bundled": true
         },
         "lodash._getnative": {
           "version": "3.9.1",
@@ -5779,10 +3863,6 @@
         "lru-cache": {
           "version": "4.1.1",
           "bundled": true,
-          "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
-          },
           "dependencies": {
             "pseudomap": {
               "version": "1.0.2",
@@ -5801,27 +3881,10 @@
         "mississippi": {
           "version": "1.3.0",
           "bundled": true,
-          "requires": {
-            "concat-stream": "1.6.0",
-            "duplexify": "3.5.0",
-            "end-of-stream": "1.4.0",
-            "flush-write-stream": "1.0.2",
-            "from2": "2.3.0",
-            "parallel-transform": "1.1.0",
-            "pump": "1.0.2",
-            "pumpify": "1.3.5",
-            "stream-each": "1.2.0",
-            "through2": "2.0.3"
-          },
           "dependencies": {
             "concat-stream": {
               "version": "1.6.0",
               "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3",
-                "typedarray": "0.0.6"
-              },
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
@@ -5832,26 +3895,14 @@
             "duplexify": {
               "version": "3.5.0",
               "bundled": true,
-              "requires": {
-                "end-of-stream": "1.0.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3",
-                "stream-shift": "1.0.0"
-              },
               "dependencies": {
                 "end-of-stream": {
                   "version": "1.0.0",
                   "bundled": true,
-                  "requires": {
-                    "once": "1.3.3"
-                  },
                   "dependencies": {
                     "once": {
                       "version": "1.3.3",
-                      "bundled": true,
-                      "requires": {
-                        "wrappy": "1.0.2"
-                      }
+                      "bundled": true
                     }
                   }
                 },
@@ -5863,35 +3914,19 @@
             },
             "end-of-stream": {
               "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "once": "1.4.0"
-              }
+              "bundled": true
             },
             "flush-write-stream": {
               "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3"
-              }
+              "bundled": true
             },
             "from2": {
               "version": "2.3.0",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3"
-              }
+              "bundled": true
             },
             "parallel-transform": {
               "version": "1.1.0",
               "bundled": true,
-              "requires": {
-                "cyclist": "0.2.2",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3"
-              },
               "dependencies": {
                 "cyclist": {
                   "version": "0.2.2",
@@ -5901,28 +3936,15 @@
             },
             "pump": {
               "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "end-of-stream": "1.4.0",
-                "once": "1.4.0"
-              }
+              "bundled": true
             },
             "pumpify": {
               "version": "1.3.5",
-              "bundled": true,
-              "requires": {
-                "duplexify": "3.5.0",
-                "inherits": "2.0.3",
-                "pump": "1.0.2"
-              }
+              "bundled": true
             },
             "stream-each": {
               "version": "1.2.0",
               "bundled": true,
-              "requires": {
-                "end-of-stream": "1.4.0",
-                "stream-shift": "1.0.0"
-              },
               "dependencies": {
                 "stream-shift": {
                   "version": "1.0.0",
@@ -5933,10 +3955,6 @@
             "through2": {
               "version": "2.0.3",
               "bundled": true,
-              "requires": {
-                "readable-stream": "2.3.3",
-                "xtend": "4.0.1"
-              },
               "dependencies": {
                 "xtend": {
                   "version": "4.0.1",
@@ -5949,9 +3967,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "requires": {
-            "minimist": "0.0.8"
-          },
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
@@ -5962,79 +3977,32 @@
         "move-concurrently": {
           "version": "1.0.1",
           "bundled": true,
-          "requires": {
-            "aproba": "1.2.0",
-            "copy-concurrently": "1.0.5",
-            "fs-write-stream-atomic": "1.0.10",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2",
-            "run-queue": "1.0.3"
-          },
           "dependencies": {
             "copy-concurrently": {
               "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "aproba": "1.2.0",
-                "fs-write-stream-atomic": "1.0.10",
-                "iferr": "0.1.5",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2",
-                "run-queue": "1.0.3"
-              }
+              "bundled": true
             },
             "run-queue": {
               "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "aproba": "1.2.0"
-              }
+              "bundled": true
             }
           }
         },
         "node-gyp": {
           "version": "3.6.2",
           "bundled": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "nopt": "3.0.6",
-            "npmlog": "4.1.2",
-            "osenv": "0.1.4",
-            "request": "2.83.0",
-            "rimraf": "2.6.2",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "which": "1.3.0"
-          },
           "dependencies": {
             "fstream": {
               "version": "1.0.11",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
-              }
+              "bundled": true
             },
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
                   "bundled": true,
-                  "requires": {
-                    "balanced-match": "1.0.0",
-                    "concat-map": "0.0.1"
-                  },
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
@@ -6050,10 +4018,7 @@
             },
             "nopt": {
               "version": "3.0.6",
-              "bundled": true,
-              "requires": {
-                "abbrev": "1.1.1"
-              }
+              "bundled": true
             },
             "semver": {
               "version": "5.3.0",
@@ -6062,18 +4027,10 @@
             "tar": {
               "version": "2.2.1",
               "bundled": true,
-              "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
-              },
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.9",
-                  "bundled": true,
-                  "requires": {
-                    "inherits": "2.0.3"
-                  }
+                  "bundled": true
                 }
               }
             }
@@ -6081,28 +4038,15 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
-          "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.4"
-          }
+          "bundled": true
         },
         "normalize-package-data": {
           "version": "2.4.0",
           "bundled": true,
-          "requires": {
-            "hosted-git-info": "2.5.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.4.1",
-            "validate-npm-package-license": "3.0.1"
-          },
           "dependencies": {
             "is-builtin-module": {
               "version": "1.0.0",
               "bundled": true,
-              "requires": {
-                "builtin-modules": "1.1.1"
-              },
               "dependencies": {
                 "builtin-modules": {
                   "version": "1.1.1",
@@ -6118,24 +4062,11 @@
         },
         "npm-install-checks": {
           "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "semver": "5.4.1"
-          }
+          "bundled": true
         },
         "npm-lifecycle": {
           "version": "2.0.0",
           "bundled": true,
-          "requires": {
-            "byline": "5.0.0",
-            "graceful-fs": "4.1.11",
-            "node-gyp": "3.6.2",
-            "resolve-from": "4.0.0",
-            "slide": "1.1.6",
-            "uid-number": "0.0.6",
-            "umask": "1.1.0",
-            "which": "1.3.0"
-          },
           "dependencies": {
             "byline": {
               "version": "5.0.0",
@@ -6149,43 +4080,23 @@
         },
         "npm-package-arg": {
           "version": "6.0.0",
-          "bundled": true,
-          "requires": {
-            "hosted-git-info": "2.5.0",
-            "osenv": "0.1.4",
-            "semver": "5.4.1",
-            "validate-npm-package-name": "3.0.0"
-          }
+          "bundled": true
         },
         "npm-packlist": {
           "version": "1.1.10",
           "bundled": true,
-          "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
-          },
           "dependencies": {
             "ignore-walk": {
               "version": "3.0.1",
               "bundled": true,
-              "requires": {
-                "minimatch": "3.0.4"
-              },
               "dependencies": {
                 "minimatch": {
                   "version": "3.0.4",
                   "bundled": true,
-                  "requires": {
-                    "brace-expansion": "1.1.8"
-                  },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
                       "bundled": true,
-                      "requires": {
-                        "balanced-match": "1.0.0",
-                        "concat-map": "0.0.1"
-                      },
                       "dependencies": {
                         "balanced-match": {
                           "version": "1.0.0",
@@ -6210,41 +4121,18 @@
         "npm-profile": {
           "version": "2.0.5",
           "bundled": true,
-          "requires": {
-            "aproba": "1.2.0",
-            "make-fetch-happen": "2.5.0"
-          },
           "dependencies": {
             "make-fetch-happen": {
               "version": "2.5.0",
               "bundled": true,
-              "requires": {
-                "agentkeepalive": "3.3.0",
-                "cacache": "9.3.0",
-                "http-cache-semantics": "3.8.0",
-                "http-proxy-agent": "2.0.0",
-                "https-proxy-agent": "2.1.0",
-                "lru-cache": "4.1.1",
-                "mississippi": "1.3.0",
-                "node-fetch-npm": "2.0.2",
-                "promise-retry": "1.1.1",
-                "socks-proxy-agent": "3.0.1",
-                "ssri": "4.1.6"
-              },
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.3.0",
                   "bundled": true,
-                  "requires": {
-                    "humanize-ms": "1.2.1"
-                  },
                   "dependencies": {
                     "humanize-ms": {
                       "version": "1.2.1",
                       "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
@@ -6257,21 +4145,6 @@
                 "cacache": {
                   "version": "9.3.0",
                   "bundled": true,
-                  "requires": {
-                    "bluebird": "3.5.1",
-                    "chownr": "1.0.1",
-                    "glob": "7.1.2",
-                    "graceful-fs": "4.1.11",
-                    "lru-cache": "4.1.1",
-                    "mississippi": "1.3.0",
-                    "mkdirp": "0.5.1",
-                    "move-concurrently": "1.0.1",
-                    "promise-inflight": "1.0.1",
-                    "rimraf": "2.6.2",
-                    "ssri": "4.1.6",
-                    "unique-filename": "1.1.0",
-                    "y18n": "3.2.1"
-                  },
                   "dependencies": {
                     "y18n": {
                       "version": "3.2.1",
@@ -6286,24 +4159,14 @@
                 "http-proxy-agent": {
                   "version": "2.0.0",
                   "bundled": true,
-                  "requires": {
-                    "agent-base": "4.1.1",
-                    "debug": "2.6.9"
-                  },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.1",
                       "bundled": true,
-                      "requires": {
-                        "es6-promisify": "5.0.0"
-                      },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
-                          "requires": {
-                            "es6-promise": "4.1.1"
-                          },
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
@@ -6316,9 +4179,6 @@
                     "debug": {
                       "version": "2.6.9",
                       "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
@@ -6331,24 +4191,14 @@
                 "https-proxy-agent": {
                   "version": "2.1.0",
                   "bundled": true,
-                  "requires": {
-                    "agent-base": "4.1.1",
-                    "debug": "2.6.9"
-                  },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.1",
                       "bundled": true,
-                      "requires": {
-                        "es6-promisify": "5.0.0"
-                      },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
-                          "requires": {
-                            "es6-promise": "4.1.1"
-                          },
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
@@ -6361,9 +4211,6 @@
                     "debug": {
                       "version": "2.6.9",
                       "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
@@ -6376,18 +4223,10 @@
                 "node-fetch-npm": {
                   "version": "2.0.2",
                   "bundled": true,
-                  "requires": {
-                    "encoding": "0.1.12",
-                    "json-parse-better-errors": "1.0.1",
-                    "safe-buffer": "5.1.1"
-                  },
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
                       "bundled": true,
-                      "requires": {
-                        "iconv-lite": "0.4.19"
-                      },
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.19",
@@ -6404,10 +4243,6 @@
                 "promise-retry": {
                   "version": "1.1.1",
                   "bundled": true,
-                  "requires": {
-                    "err-code": "1.1.2",
-                    "retry": "0.10.1"
-                  },
                   "dependencies": {
                     "err-code": {
                       "version": "1.1.2",
@@ -6418,24 +4253,14 @@
                 "socks-proxy-agent": {
                   "version": "3.0.1",
                   "bundled": true,
-                  "requires": {
-                    "agent-base": "4.1.1",
-                    "socks": "1.1.10"
-                  },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.1",
                       "bundled": true,
-                      "requires": {
-                        "es6-promisify": "5.0.0"
-                      },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
-                          "requires": {
-                            "es6-promise": "4.1.1"
-                          },
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
@@ -6448,10 +4273,6 @@
                     "socks": {
                       "version": "1.1.10",
                       "bundled": true,
-                      "requires": {
-                        "ip": "1.1.5",
-                        "smart-buffer": "1.1.15"
-                      },
                       "dependencies": {
                         "ip": {
                           "version": "1.1.5",
@@ -6467,10 +4288,7 @@
                 },
                 "ssri": {
                   "version": "4.1.6",
-                  "bundled": true,
-                  "requires": {
-                    "safe-buffer": "5.1.1"
-                  }
+                  "bundled": true
                 }
               }
             }
@@ -6479,28 +4297,10 @@
         "npm-registry-client": {
           "version": "8.5.0",
           "bundled": true,
-          "requires": {
-            "concat-stream": "1.6.0",
-            "graceful-fs": "4.1.11",
-            "normalize-package-data": "2.4.0",
-            "npm-package-arg": "5.1.2",
-            "npmlog": "4.1.2",
-            "once": "1.4.0",
-            "request": "2.83.0",
-            "retry": "0.10.1",
-            "semver": "5.4.1",
-            "slide": "1.1.6",
-            "ssri": "4.1.6"
-          },
           "dependencies": {
             "concat-stream": {
               "version": "1.6.0",
               "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3",
-                "typedarray": "0.0.6"
-              },
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
@@ -6510,20 +4310,11 @@
             },
             "npm-package-arg": {
               "version": "5.1.2",
-              "bundled": true,
-              "requires": {
-                "hosted-git-info": "2.5.0",
-                "osenv": "0.1.4",
-                "semver": "5.4.1",
-                "validate-npm-package-name": "3.0.0"
-              }
+              "bundled": true
             },
             "ssri": {
               "version": "4.1.6",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
+              "bundled": true
             }
           }
         },
@@ -6534,20 +4325,10 @@
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          },
           "dependencies": {
             "are-we-there-yet": {
               "version": "1.1.4",
               "bundled": true,
-              "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.3.3"
-              },
               "dependencies": {
                 "delegates": {
                   "version": "1.0.0",
@@ -6562,16 +4343,6 @@
             "gauge": {
               "version": "2.7.4",
               "bundled": true,
-              "requires": {
-                "aproba": "1.2.0",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.2"
-              },
               "dependencies": {
                 "object-assign": {
                   "version": "4.1.1",
@@ -6584,11 +4355,6 @@
                 "string-width": {
                   "version": "1.0.2",
                   "bundled": true,
-                  "requires": {
-                    "code-point-at": "1.1.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
-                  },
                   "dependencies": {
                     "code-point-at": {
                       "version": "1.1.0",
@@ -6597,9 +4363,6 @@
                     "is-fullwidth-code-point": {
                       "version": "1.0.0",
                       "bundled": true,
-                      "requires": {
-                        "number-is-nan": "1.0.1"
-                      },
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.1",
@@ -6612,9 +4375,6 @@
                 "strip-ansi": {
                   "version": "3.0.1",
                   "bundled": true,
-                  "requires": {
-                    "ansi-regex": "2.1.1"
-                  },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
@@ -6624,10 +4384,7 @@
                 },
                 "wide-align": {
                   "version": "1.1.2",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "1.0.2"
-                  }
+                  "bundled": true
                 }
               }
             },
@@ -6639,10 +4396,7 @@
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
+          "bundled": true
         },
         "opener": {
           "version": "1.4.3",
@@ -6651,10 +4405,6 @@
         "osenv": {
           "version": "0.1.4",
           "bundled": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          },
           "dependencies": {
             "os-homedir": {
               "version": "1.0.2",
@@ -6669,30 +4419,6 @@
         "pacote": {
           "version": "7.0.2",
           "bundled": true,
-          "requires": {
-            "bluebird": "3.5.1",
-            "cacache": "10.0.1",
-            "get-stream": "3.0.0",
-            "glob": "7.1.2",
-            "lru-cache": "4.1.1",
-            "make-fetch-happen": "2.6.0",
-            "minimatch": "3.0.4",
-            "mississippi": "1.3.0",
-            "normalize-package-data": "2.4.0",
-            "npm-package-arg": "6.0.0",
-            "npm-packlist": "1.1.10",
-            "npm-pick-manifest": "2.1.0",
-            "osenv": "0.1.4",
-            "promise-inflight": "1.0.1",
-            "promise-retry": "1.1.1",
-            "protoduck": "4.0.0",
-            "safe-buffer": "5.1.1",
-            "semver": "5.4.1",
-            "ssri": "5.0.0",
-            "tar": "4.0.2",
-            "unique-filename": "1.1.0",
-            "which": "1.3.0"
-          },
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
@@ -6701,33 +4427,14 @@
             "make-fetch-happen": {
               "version": "2.6.0",
               "bundled": true,
-              "requires": {
-                "agentkeepalive": "3.3.0",
-                "cacache": "10.0.1",
-                "http-cache-semantics": "3.8.0",
-                "http-proxy-agent": "2.0.0",
-                "https-proxy-agent": "2.1.0",
-                "lru-cache": "4.1.1",
-                "mississippi": "1.3.0",
-                "node-fetch-npm": "2.0.2",
-                "promise-retry": "1.1.1",
-                "socks-proxy-agent": "3.0.1",
-                "ssri": "5.0.0"
-              },
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.3.0",
                   "bundled": true,
-                  "requires": {
-                    "humanize-ms": "1.2.1"
-                  },
                   "dependencies": {
                     "humanize-ms": {
                       "version": "1.2.1",
                       "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
@@ -6744,24 +4451,14 @@
                 "http-proxy-agent": {
                   "version": "2.0.0",
                   "bundled": true,
-                  "requires": {
-                    "agent-base": "4.1.2",
-                    "debug": "2.6.9"
-                  },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.2",
                       "bundled": true,
-                      "requires": {
-                        "es6-promisify": "5.0.0"
-                      },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
-                          "requires": {
-                            "es6-promise": "4.1.1"
-                          },
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
@@ -6774,9 +4471,6 @@
                     "debug": {
                       "version": "2.6.9",
                       "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
@@ -6789,24 +4483,14 @@
                 "https-proxy-agent": {
                   "version": "2.1.0",
                   "bundled": true,
-                  "requires": {
-                    "agent-base": "4.1.2",
-                    "debug": "2.6.9"
-                  },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.2",
                       "bundled": true,
-                      "requires": {
-                        "es6-promisify": "5.0.0"
-                      },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
-                          "requires": {
-                            "es6-promise": "4.1.1"
-                          },
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
@@ -6819,9 +4503,6 @@
                     "debug": {
                       "version": "2.6.9",
                       "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
@@ -6834,18 +4515,10 @@
                 "node-fetch-npm": {
                   "version": "2.0.2",
                   "bundled": true,
-                  "requires": {
-                    "encoding": "0.1.12",
-                    "json-parse-better-errors": "1.0.1",
-                    "safe-buffer": "5.1.1"
-                  },
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
                       "bundled": true,
-                      "requires": {
-                        "iconv-lite": "0.4.19"
-                      },
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.19",
@@ -6862,24 +4535,14 @@
                 "socks-proxy-agent": {
                   "version": "3.0.1",
                   "bundled": true,
-                  "requires": {
-                    "agent-base": "4.1.2",
-                    "socks": "1.1.10"
-                  },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.2",
                       "bundled": true,
-                      "requires": {
-                        "es6-promisify": "5.0.0"
-                      },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
-                          "requires": {
-                            "es6-promise": "4.1.1"
-                          },
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
@@ -6892,10 +4555,6 @@
                     "socks": {
                       "version": "1.1.10",
                       "bundled": true,
-                      "requires": {
-                        "ip": "1.1.5",
-                        "smart-buffer": "1.1.15"
-                      },
                       "dependencies": {
                         "ip": {
                           "version": "1.1.5",
@@ -6914,17 +4573,10 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
                   "bundled": true,
-                  "requires": {
-                    "balanced-match": "1.0.0",
-                    "concat-map": "0.0.1"
-                  },
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
@@ -6940,19 +4592,11 @@
             },
             "npm-pick-manifest": {
               "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "npm-package-arg": "6.0.0",
-                "semver": "5.4.1"
-              }
+              "bundled": true
             },
             "promise-retry": {
               "version": "1.1.1",
               "bundled": true,
-              "requires": {
-                "err-code": "1.1.2",
-                "retry": "0.10.1"
-              },
               "dependencies": {
                 "err-code": {
                   "version": "1.1.2",
@@ -6963,9 +4607,6 @@
             "protoduck": {
               "version": "4.0.0",
               "bundled": true,
-              "requires": {
-                "genfun": "4.0.1"
-              },
               "dependencies": {
                 "genfun": {
                   "version": "4.0.1",
@@ -6990,11 +4631,6 @@
         "query-string": {
           "version": "5.0.1",
           "bundled": true,
-          "requires": {
-            "decode-uri-component": "0.2.0",
-            "object-assign": "4.1.1",
-            "strict-uri-encode": "1.1.0"
-          },
           "dependencies": {
             "decode-uri-component": {
               "version": "0.2.0",
@@ -7017,9 +4653,6 @@
         "read": {
           "version": "1.0.7",
           "bundled": true,
-          "requires": {
-            "mute-stream": "0.0.7"
-          },
           "dependencies": {
             "mute-stream": {
               "version": "0.0.7",
@@ -7029,23 +4662,11 @@
         },
         "read-cmd-shim": {
           "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11"
-          }
+          "bundled": true
         },
         "read-installed": {
           "version": "4.0.3",
           "bundled": true,
-          "requires": {
-            "debuglog": "1.0.1",
-            "graceful-fs": "4.1.11",
-            "read-package-json": "2.0.12",
-            "readdir-scoped-modules": "1.0.2",
-            "semver": "5.4.1",
-            "slide": "1.1.6",
-            "util-extend": "1.0.3"
-          },
           "dependencies": {
             "util-extend": {
               "version": "1.0.3",
@@ -7056,13 +4677,6 @@
         "read-package-json": {
           "version": "2.0.12",
           "bundled": true,
-          "requires": {
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "json-parse-better-errors": "1.0.1",
-            "normalize-package-data": "2.4.0",
-            "slash": "1.0.0"
-          },
           "dependencies": {
             "json-parse-better-errors": {
               "version": "1.0.1",
@@ -7076,27 +4690,11 @@
         },
         "read-package-tree": {
           "version": "5.1.6",
-          "bundled": true,
-          "requires": {
-            "debuglog": "1.0.1",
-            "dezalgo": "1.0.3",
-            "once": "1.4.0",
-            "read-package-json": "2.0.12",
-            "readdir-scoped-modules": "1.0.2"
-          }
+          "bundled": true
         },
         "readable-stream": {
           "version": "2.3.3",
           "bundled": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          },
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
@@ -7112,10 +4710,7 @@
             },
             "string_decoder": {
               "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
+              "bundled": true
             },
             "util-deprecate": {
               "version": "1.0.2",
@@ -7125,41 +4720,11 @@
         },
         "readdir-scoped-modules": {
           "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "debuglog": "1.0.1",
-            "dezalgo": "1.0.3",
-            "graceful-fs": "4.1.11",
-            "once": "1.4.0"
-          }
+          "bundled": true
         },
         "request": {
           "version": "2.83.0",
           "bundled": true,
-          "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
-          },
           "dependencies": {
             "aws-sign2": {
               "version": "0.7.0",
@@ -7176,9 +4741,6 @@
             "combined-stream": {
               "version": "1.0.5",
               "bundled": true,
-              "requires": {
-                "delayed-stream": "1.0.0"
-              },
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
@@ -7197,11 +4759,6 @@
             "form-data": {
               "version": "2.3.1",
               "bundled": true,
-              "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
-              },
               "dependencies": {
                 "asynckit": {
                   "version": "0.4.0",
@@ -7212,20 +4769,10 @@
             "har-validator": {
               "version": "5.0.3",
               "bundled": true,
-              "requires": {
-                "ajv": "5.2.3",
-                "har-schema": "2.0.0"
-              },
               "dependencies": {
                 "ajv": {
                   "version": "5.2.3",
                   "bundled": true,
-                  "requires": {
-                    "co": "4.6.0",
-                    "fast-deep-equal": "1.0.0",
-                    "json-schema-traverse": "0.3.1",
-                    "json-stable-stringify": "1.0.1"
-                  },
                   "dependencies": {
                     "co": {
                       "version": "4.6.0",
@@ -7242,9 +4789,6 @@
                     "json-stable-stringify": {
                       "version": "1.0.1",
                       "bundled": true,
-                      "requires": {
-                        "jsonify": "0.0.0"
-                      },
                       "dependencies": {
                         "jsonify": {
                           "version": "0.0.0",
@@ -7263,33 +4807,18 @@
             "hawk": {
               "version": "6.0.2",
               "bundled": true,
-              "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.0",
-                "sntp": "2.0.2"
-              },
               "dependencies": {
                 "boom": {
                   "version": "4.3.1",
-                  "bundled": true,
-                  "requires": {
-                    "hoek": "4.2.0"
-                  }
+                  "bundled": true
                 },
                 "cryptiles": {
                   "version": "3.1.2",
                   "bundled": true,
-                  "requires": {
-                    "boom": "5.2.0"
-                  },
                   "dependencies": {
                     "boom": {
                       "version": "5.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "hoek": "4.2.0"
-                      }
+                      "bundled": true
                     }
                   }
                 },
@@ -7299,21 +4828,13 @@
                 },
                 "sntp": {
                   "version": "2.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "hoek": "4.2.0"
-                  }
+                  "bundled": true
                 }
               }
             },
             "http-signature": {
               "version": "1.2.0",
               "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
-              },
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
@@ -7322,12 +4843,6 @@
                 "jsprim": {
                   "version": "1.4.1",
                   "bundled": true,
-                  "requires": {
-                    "assert-plus": "1.0.0",
-                    "extsprintf": "1.3.0",
-                    "json-schema": "0.2.3",
-                    "verror": "1.10.0"
-                  },
                   "dependencies": {
                     "extsprintf": {
                       "version": "1.3.0",
@@ -7340,11 +4855,6 @@
                     "verror": {
                       "version": "1.10.0",
                       "bundled": true,
-                      "requires": {
-                        "assert-plus": "1.0.0",
-                        "core-util-is": "1.0.2",
-                        "extsprintf": "1.3.0"
-                      },
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
@@ -7357,16 +4867,6 @@
                 "sshpk": {
                   "version": "1.13.1",
                   "bundled": true,
-                  "requires": {
-                    "asn1": "0.2.3",
-                    "assert-plus": "1.0.0",
-                    "bcrypt-pbkdf": "1.0.1",
-                    "dashdash": "1.14.1",
-                    "ecc-jsbn": "0.1.1",
-                    "getpass": "0.1.7",
-                    "jsbn": "0.1.1",
-                    "tweetnacl": "0.14.5"
-                  },
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
@@ -7375,32 +4875,20 @@
                     "bcrypt-pbkdf": {
                       "version": "1.0.1",
                       "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "tweetnacl": "0.14.5"
-                      }
+                      "optional": true
                     },
                     "dashdash": {
                       "version": "1.14.1",
-                      "bundled": true,
-                      "requires": {
-                        "assert-plus": "1.0.0"
-                      }
+                      "bundled": true
                     },
                     "ecc-jsbn": {
                       "version": "0.1.1",
                       "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "jsbn": "0.1.1"
-                      }
+                      "optional": true
                     },
                     "getpass": {
                       "version": "0.1.7",
-                      "bundled": true,
-                      "requires": {
-                        "assert-plus": "1.0.0"
-                      }
+                      "bundled": true
                     },
                     "jsbn": {
                       "version": "0.1.1",
@@ -7431,9 +4919,6 @@
             "mime-types": {
               "version": "2.1.17",
               "bundled": true,
-              "requires": {
-                "mime-db": "1.30.0"
-              },
               "dependencies": {
                 "mime-db": {
                   "version": "1.30.0",
@@ -7460,9 +4945,6 @@
             "tough-cookie": {
               "version": "2.3.3",
               "bundled": true,
-              "requires": {
-                "punycode": "1.4.1"
-              },
               "dependencies": {
                 "punycode": {
                   "version": "1.4.1",
@@ -7472,10 +4954,7 @@
             },
             "tunnel-agent": {
               "version": "0.6.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
+              "bundled": true
             }
           }
         },
@@ -7485,10 +4964,7 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
+          "bundled": true
         },
         "safe-buffer": {
           "version": "5.1.1",
@@ -7500,11 +4976,7 @@
         },
         "sha": {
           "version": "2.0.1",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "readable-stream": "2.3.3"
-          }
+          "bundled": true
         },
         "slide": {
           "version": "1.1.6",
@@ -7517,28 +4989,14 @@
         "sorted-union-stream": {
           "version": "2.1.3",
           "bundled": true,
-          "requires": {
-            "from2": "1.3.0",
-            "stream-iterate": "1.2.0"
-          },
           "dependencies": {
             "from2": {
               "version": "1.3.0",
               "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "1.1.14"
-              },
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.14",
                   "bundled": true,
-                  "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.3",
-                    "isarray": "0.0.1",
-                    "string_decoder": "0.10.31"
-                  },
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
@@ -7559,10 +5017,6 @@
             "stream-iterate": {
               "version": "1.2.0",
               "bundled": true,
-              "requires": {
-                "readable-stream": "2.3.3",
-                "stream-shift": "1.0.0"
-              },
               "dependencies": {
                 "stream-shift": {
                   "version": "1.0.0",
@@ -7574,17 +5028,11 @@
         },
         "ssri": {
           "version": "5.0.0",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "bundled": true
         },
         "strip-ansi": {
           "version": "4.0.0",
           "bundled": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          },
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
@@ -7595,27 +5043,14 @@
         "tar": {
           "version": "4.0.2",
           "bundled": true,
-          "requires": {
-            "chownr": "1.0.1",
-            "minipass": "2.2.1",
-            "minizlib": "1.0.4",
-            "mkdirp": "0.5.1",
-            "yallist": "3.0.2"
-          },
           "dependencies": {
             "minipass": {
               "version": "2.2.1",
-              "bundled": true,
-              "requires": {
-                "yallist": "3.0.2"
-              }
+              "bundled": true
             },
             "minizlib": {
               "version": "1.0.4",
-              "bundled": true,
-              "requires": {
-                "minipass": "2.2.1"
-              }
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.2",
@@ -7638,16 +5073,10 @@
         "unique-filename": {
           "version": "1.1.0",
           "bundled": true,
-          "requires": {
-            "unique-slug": "2.0.0"
-          },
           "dependencies": {
             "unique-slug": {
               "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "imurmurhash": "0.1.4"
-              }
+              "bundled": true
             }
           }
         },
@@ -7658,37 +5087,14 @@
         "update-notifier": {
           "version": "2.3.0",
           "bundled": true,
-          "requires": {
-            "boxen": "1.2.1",
-            "chalk": "2.1.0",
-            "configstore": "3.1.1",
-            "import-lazy": "2.1.0",
-            "is-installed-globally": "0.1.0",
-            "is-npm": "1.0.0",
-            "latest-version": "3.1.0",
-            "semver-diff": "2.1.0",
-            "xdg-basedir": "3.0.0"
-          },
           "dependencies": {
             "boxen": {
               "version": "1.2.1",
               "bundled": true,
-              "requires": {
-                "ansi-align": "2.0.0",
-                "camelcase": "4.1.0",
-                "chalk": "2.1.0",
-                "cli-boxes": "1.0.0",
-                "string-width": "2.1.1",
-                "term-size": "1.2.0",
-                "widest-line": "1.0.0"
-              },
               "dependencies": {
                 "ansi-align": {
                   "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "2.1.1"
-                  }
+                  "bundled": true
                 },
                 "camelcase": {
                   "version": "4.1.0",
@@ -7701,10 +5107,6 @@
                 "string-width": {
                   "version": "2.1.1",
                   "bundled": true,
-                  "requires": {
-                    "is-fullwidth-code-point": "2.0.0",
-                    "strip-ansi": "4.0.0"
-                  },
                   "dependencies": {
                     "is-fullwidth-code-point": {
                       "version": "2.0.0",
@@ -7715,38 +5117,18 @@
                 "term-size": {
                   "version": "1.2.0",
                   "bundled": true,
-                  "requires": {
-                    "execa": "0.7.0"
-                  },
                   "dependencies": {
                     "execa": {
                       "version": "0.7.0",
                       "bundled": true,
-                      "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
-                      },
                       "dependencies": {
                         "cross-spawn": {
                           "version": "5.1.0",
                           "bundled": true,
-                          "requires": {
-                            "lru-cache": "4.1.1",
-                            "shebang-command": "1.2.0",
-                            "which": "1.3.0"
-                          },
                           "dependencies": {
                             "shebang-command": {
                               "version": "1.2.0",
                               "bundled": true,
-                              "requires": {
-                                "shebang-regex": "1.0.0"
-                              },
                               "dependencies": {
                                 "shebang-regex": {
                                   "version": "1.0.0",
@@ -7767,9 +5149,6 @@
                         "npm-run-path": {
                           "version": "2.0.2",
                           "bundled": true,
-                          "requires": {
-                            "path-key": "2.0.1"
-                          },
                           "dependencies": {
                             "path-key": {
                               "version": "2.0.1",
@@ -7796,18 +5175,10 @@
                 "widest-line": {
                   "version": "1.0.0",
                   "bundled": true,
-                  "requires": {
-                    "string-width": "1.0.2"
-                  },
                   "dependencies": {
                     "string-width": {
                       "version": "1.0.2",
                       "bundled": true,
-                      "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
-                      },
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.1.0",
@@ -7816,9 +5187,6 @@
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
                           "bundled": true,
-                          "requires": {
-                            "number-is-nan": "1.0.1"
-                          },
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
@@ -7829,9 +5197,6 @@
                         "strip-ansi": {
                           "version": "3.0.1",
                           "bundled": true,
-                          "requires": {
-                            "ansi-regex": "2.1.1"
-                          },
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.1.1",
@@ -7848,25 +5213,14 @@
             "chalk": {
               "version": "2.1.0",
               "bundled": true,
-              "requires": {
-                "ansi-styles": "3.2.0",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "4.4.0"
-              },
               "dependencies": {
                 "ansi-styles": {
                   "version": "3.2.0",
                   "bundled": true,
-                  "requires": {
-                    "color-convert": "1.9.0"
-                  },
                   "dependencies": {
                     "color-convert": {
                       "version": "1.9.0",
                       "bundled": true,
-                      "requires": {
-                        "color-name": "1.1.3"
-                      },
                       "dependencies": {
                         "color-name": {
                           "version": "1.1.3",
@@ -7883,9 +5237,6 @@
                 "supports-color": {
                   "version": "4.4.0",
                   "bundled": true,
-                  "requires": {
-                    "has-flag": "2.0.0"
-                  },
                   "dependencies": {
                     "has-flag": {
                       "version": "2.0.0",
@@ -7898,21 +5249,10 @@
             "configstore": {
               "version": "3.1.1",
               "bundled": true,
-              "requires": {
-                "dot-prop": "4.2.0",
-                "graceful-fs": "4.1.11",
-                "make-dir": "1.0.0",
-                "unique-string": "1.0.0",
-                "write-file-atomic": "2.1.0",
-                "xdg-basedir": "3.0.0"
-              },
               "dependencies": {
                 "dot-prop": {
                   "version": "4.2.0",
                   "bundled": true,
-                  "requires": {
-                    "is-obj": "1.0.1"
-                  },
                   "dependencies": {
                     "is-obj": {
                       "version": "1.0.1",
@@ -7923,9 +5263,6 @@
                 "make-dir": {
                   "version": "1.0.0",
                   "bundled": true,
-                  "requires": {
-                    "pify": "2.3.0"
-                  },
                   "dependencies": {
                     "pify": {
                       "version": "2.3.0",
@@ -7936,9 +5273,6 @@
                 "unique-string": {
                   "version": "1.0.0",
                   "bundled": true,
-                  "requires": {
-                    "crypto-random-string": "1.0.0"
-                  },
                   "dependencies": {
                     "crypto-random-string": {
                       "version": "1.0.0",
@@ -7955,24 +5289,14 @@
             "is-installed-globally": {
               "version": "0.1.0",
               "bundled": true,
-              "requires": {
-                "global-dirs": "0.1.0",
-                "is-path-inside": "1.0.0"
-              },
               "dependencies": {
                 "global-dirs": {
                   "version": "0.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "ini": "1.3.4"
-                  }
+                  "bundled": true
                 },
                 "is-path-inside": {
                   "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "path-is-inside": "1.0.2"
-                  }
+                  "bundled": true
                 }
               }
             },
@@ -7983,43 +5307,18 @@
             "latest-version": {
               "version": "3.1.0",
               "bundled": true,
-              "requires": {
-                "package-json": "4.0.1"
-              },
               "dependencies": {
                 "package-json": {
                   "version": "4.0.1",
                   "bundled": true,
-                  "requires": {
-                    "got": "6.7.1",
-                    "registry-auth-token": "3.3.1",
-                    "registry-url": "3.1.0",
-                    "semver": "5.4.1"
-                  },
                   "dependencies": {
                     "got": {
                       "version": "6.7.1",
                       "bundled": true,
-                      "requires": {
-                        "create-error-class": "3.0.2",
-                        "duplexer3": "0.1.4",
-                        "get-stream": "3.0.0",
-                        "is-redirect": "1.0.0",
-                        "is-retry-allowed": "1.1.0",
-                        "is-stream": "1.1.0",
-                        "lowercase-keys": "1.0.0",
-                        "safe-buffer": "5.1.1",
-                        "timed-out": "4.0.1",
-                        "unzip-response": "2.0.1",
-                        "url-parse-lax": "1.0.0"
-                      },
                       "dependencies": {
                         "create-error-class": {
                           "version": "3.0.2",
                           "bundled": true,
-                          "requires": {
-                            "capture-stack-trace": "1.0.0"
-                          },
                           "dependencies": {
                             "capture-stack-trace": {
                               "version": "1.0.0",
@@ -8062,9 +5361,6 @@
                         "url-parse-lax": {
                           "version": "1.0.0",
                           "bundled": true,
-                          "requires": {
-                            "prepend-http": "1.0.4"
-                          },
                           "dependencies": {
                             "prepend-http": {
                               "version": "1.0.4",
@@ -8077,20 +5373,10 @@
                     "registry-auth-token": {
                       "version": "3.3.1",
                       "bundled": true,
-                      "requires": {
-                        "rc": "1.2.1",
-                        "safe-buffer": "5.1.1"
-                      },
                       "dependencies": {
                         "rc": {
                           "version": "1.2.1",
                           "bundled": true,
-                          "requires": {
-                            "deep-extend": "0.4.2",
-                            "ini": "1.3.4",
-                            "minimist": "1.2.0",
-                            "strip-json-comments": "2.0.1"
-                          },
                           "dependencies": {
                             "deep-extend": {
                               "version": "0.4.2",
@@ -8111,19 +5397,10 @@
                     "registry-url": {
                       "version": "3.1.0",
                       "bundled": true,
-                      "requires": {
-                        "rc": "1.2.1"
-                      },
                       "dependencies": {
                         "rc": {
                           "version": "1.2.1",
                           "bundled": true,
-                          "requires": {
-                            "deep-extend": "0.4.2",
-                            "ini": "1.3.4",
-                            "minimist": "1.2.0",
-                            "strip-json-comments": "2.0.1"
-                          },
                           "dependencies": {
                             "deep-extend": {
                               "version": "0.4.2",
@@ -8147,10 +5424,7 @@
             },
             "semver-diff": {
               "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "semver": "5.4.1"
-              }
+              "bundled": true
             },
             "xdg-basedir": {
               "version": "3.0.0",
@@ -8165,17 +5439,10 @@
         "validate-npm-package-license": {
           "version": "3.0.1",
           "bundled": true,
-          "requires": {
-            "spdx-correct": "1.0.2",
-            "spdx-expression-parse": "1.0.4"
-          },
           "dependencies": {
             "spdx-correct": {
               "version": "1.0.2",
               "bundled": true,
-              "requires": {
-                "spdx-license-ids": "1.2.2"
-              },
               "dependencies": {
                 "spdx-license-ids": {
                   "version": "1.2.2",
@@ -8192,9 +5459,6 @@
         "validate-npm-package-name": {
           "version": "3.0.0",
           "bundled": true,
-          "requires": {
-            "builtins": "1.0.3"
-          },
           "dependencies": {
             "builtins": {
               "version": "1.0.3",
@@ -8205,9 +5469,6 @@
         "which": {
           "version": "1.3.0",
           "bundled": true,
-          "requires": {
-            "isexe": "2.0.0"
-          },
           "dependencies": {
             "isexe": {
               "version": "2.0.0",
@@ -8218,17 +5479,10 @@
         "worker-farm": {
           "version": "1.5.1",
           "bundled": true,
-          "requires": {
-            "errno": "0.1.4",
-            "xtend": "4.0.1"
-          },
           "dependencies": {
             "errno": {
               "version": "0.1.4",
               "bundled": true,
-              "requires": {
-                "prr": "0.0.0"
-              },
               "dependencies": {
                 "prr": {
                   "version": "0.0.0",
@@ -8248,25 +5502,14 @@
         },
         "write-file-atomic": {
           "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
-          }
+          "bundled": true
         }
       }
     },
     "npmlog": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
-      "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
-      "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
-      }
+      "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA=="
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -8301,28 +5544,17 @@
     "object.getownpropertydescriptors": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
-      "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.12.0"
-      }
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY="
     },
     "object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
-      }
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo="
     },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "requires": {
-        "ee-first": "1.1.1"
-      }
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc="
     },
     "on-headers": {
       "version": "1.0.1",
@@ -8332,28 +5564,18 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
-        "wrappy": "1.0.2"
-      }
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
     },
     "onetime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "dev": true,
-      "requires": {
-        "mimic-fn": "1.2.0"
-      }
+      "dev": true
     },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.2"
-      },
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
@@ -8367,14 +5589,6 @@
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
-      "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
-      },
       "dependencies": {
         "wordwrap": {
           "version": "1.0.0",
@@ -8388,27 +5602,16 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
       "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
-      "requires": {
-        "end-of-stream": "0.1.5",
-        "sequencify": "0.0.7",
-        "stream-consume": "0.1.0"
-      },
       "dependencies": {
         "end-of-stream": {
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
-          "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
-          "requires": {
-            "once": "1.3.3"
-          }
+          "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8="
         },
         "once": {
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-          "requires": {
-            "wrappy": "1.0.2"
-          }
+          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA="
         }
       }
     },
@@ -8425,10 +5628,12 @@
     "os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "requires": {
-        "lcid": "1.0.0"
-      }
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk="
+    },
+    "os-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
+      "integrity": "sha1-uaOGNhwXrjohc27wWZQFyajF3F4="
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -8438,48 +5643,27 @@
     "osenv": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
+      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ="
     },
     "param-case": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
-      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
-      "requires": {
-        "no-case": "2.3.1"
-      }
+      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc="
     },
     "parse-filepath": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz",
-      "integrity": "sha1-FZ1hVdQ5BNFsEO9piRHaHpGWm3M=",
-      "requires": {
-        "is-absolute": "0.2.6",
-        "map-cache": "0.2.2",
-        "path-root": "0.1.1"
-      }
+      "integrity": "sha1-FZ1hVdQ5BNFsEO9piRHaHpGWm3M="
     },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.2",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
-      }
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw="
     },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "requires": {
-        "error-ex": "1.3.1"
-      }
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck="
     },
     "parse-listing": {
       "version": "1.1.3",
@@ -8494,26 +5678,17 @@
     "parsejson": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
-      "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
-      "requires": {
-        "better-assert": "1.0.2"
-      }
+      "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs="
     },
     "parseqs": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
-      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
-      "requires": {
-        "better-assert": "1.0.2"
-      }
+      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0="
     },
     "parseuri": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
-      "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
-      "requires": {
-        "better-assert": "1.0.2"
-      }
+      "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo="
     },
     "parseurl": {
       "version": "1.3.1",
@@ -8523,30 +5698,17 @@
     "passport": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.3.2.tgz",
-      "integrity": "sha1-ndAJ+RXo/glbASSgG4+C2gdRAQI=",
-      "requires": {
-        "passport-strategy": "1.0.0",
-        "pause": "0.0.1"
-      }
+      "integrity": "sha1-ndAJ+RXo/glbASSgG4+C2gdRAQI="
     },
     "passport-github": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/passport-github/-/passport-github-1.1.0.tgz",
-      "integrity": "sha1-jOHj/NYa11eOsd9ZWDnkrqEjVdQ=",
-      "requires": {
-        "passport-oauth2": "1.4.0"
-      }
+      "integrity": "sha1-jOHj/NYa11eOsd9ZWDnkrqEjVdQ="
     },
     "passport-oauth2": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.4.0.tgz",
-      "integrity": "sha1-9i+BWDy+EmCb585vFguTlaJ7hq0=",
-      "requires": {
-        "oauth": "0.9.15",
-        "passport-strategy": "1.0.0",
-        "uid2": "0.0.3",
-        "utils-merge": "1.0.0"
-      }
+      "integrity": "sha1-9i+BWDy+EmCb585vFguTlaJ7hq0="
     },
     "passport-strategy": {
       "version": "1.0.0",
@@ -8556,19 +5718,12 @@
     "path": {
       "version": "0.12.7",
       "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
-      "requires": {
-        "process": "0.11.10",
-        "util": "0.10.3"
-      }
+      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8="
     },
     "path-exists": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "requires": {
-        "pinkie-promise": "2.0.1"
-      }
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -8589,10 +5744,7 @@
     "path-root": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
-      "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
-      "requires": {
-        "path-root-regex": "0.1.2"
-      }
+      "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc="
     },
     "path-root-regex": {
       "version": "0.1.2",
@@ -8607,12 +5759,7 @@
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      }
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE="
     },
     "pathval": {
       "version": "1.1.0",
@@ -8642,10 +5789,7 @@
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "requires": {
-        "pinkie": "2.0.4"
-      }
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o="
     },
     "pluralize": {
       "version": "7.0.0",
@@ -8698,28 +5842,17 @@
     "progress-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-2.0.0.tgz",
-      "integrity": "sha1-+sY6Cz0R3qy7CWmrzJOyFLzhntU=",
-      "requires": {
-        "speedometer": "1.0.0",
-        "through2": "2.0.3"
-      }
+      "integrity": "sha1-+sY6Cz0R3qy7CWmrzJOyFLzhntU="
     },
     "promise-callbacks": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/promise-callbacks/-/promise-callbacks-3.1.0.tgz",
-      "integrity": "sha512-JaqBnE8IHnhEN5efQrOUK5mvVAnjya6bKg7Xl9tm/hzexlbdFrA1XWRaQE6zGdAxN+fJ79Te1GmNEZ09rHNS6A==",
-      "requires": {
-        "object.getownpropertydescriptors": "2.0.3"
-      }
+      "integrity": "sha512-JaqBnE8IHnhEN5efQrOUK5mvVAnjya6bKg7Xl9tm/hzexlbdFrA1XWRaQE6zGdAxN+fJ79Te1GmNEZ09rHNS6A=="
     },
     "proxy-addr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
-      "integrity": "sha1-J+VF9pYKRKYn2bREZ+NcG2tM4vM=",
-      "requires": {
-        "forwarded": "0.1.0",
-        "ipaddr.js": "1.3.0"
-      }
+      "integrity": "sha1-J+VF9pYKRKYn2bREZ+NcG2tM4vM="
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -8754,11 +5887,7 @@
     "randomatic": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
-      "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs=",
-      "requires": {
-        "is-number": "2.1.0",
-        "kind-of": "3.2.2"
-      }
+      "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs="
     },
     "range-parser": {
       "version": "1.2.0",
@@ -8769,14 +5898,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/raven/-/raven-2.1.1.tgz",
       "integrity": "sha1-s6l0xsKTFcZ3wHnhaENerRllJc0=",
-      "requires": {
-        "cookie": "0.3.1",
-        "json-stringify-safe": "5.0.1",
-        "lsmod": "1.0.0",
-        "stack-trace": "0.0.9",
-        "timed-out": "4.0.1",
-        "uuid": "3.0.0"
-      },
       "dependencies": {
         "uuid": {
           "version": "3.0.0",
@@ -8788,109 +5909,59 @@
     "raw-body": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
-      "integrity": "sha1-mUl2z2pQlqQRYoQEkvC9xdbn+5Y=",
-      "requires": {
-        "bytes": "2.4.0",
-        "iconv-lite": "0.4.15",
-        "unpipe": "1.0.0"
-      }
+      "integrity": "sha1-mUl2z2pQlqQRYoQEkvC9xdbn+5Y="
     },
     "rc": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-      "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.4",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
-      }
+      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU="
     },
     "read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
-      "requires": {
-        "mute-stream": "0.0.7"
-      }
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ="
     },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.3.8",
-        "path-type": "1.1.0"
-      }
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg="
     },
     "read-pkg-up": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
-      }
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI="
     },
     "readable-stream": {
       "version": "2.2.9",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-      "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
-      "requires": {
-        "buffer-shims": "1.0.0",
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "string_decoder": "1.0.1",
-        "util-deprecate": "1.0.2"
-      }
+      "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g="
     },
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "requires": {
-        "resolve": "1.3.3"
-      }
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q="
     },
     "recursive-readdir": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.1.tgz",
       "integrity": "sha1-kO8jHQd4xc4JPJpI105cVCLROpk=",
-      "requires": {
-        "minimatch": "3.0.3"
-      },
       "dependencies": {
         "minimatch": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-          "requires": {
-            "brace-expansion": "1.1.7"
-          }
+          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q="
         }
       }
     },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
-      }
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94="
     },
     "redis": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
-      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
-      "requires": {
-        "double-ended-queue": "2.1.0-0",
-        "redis-commands": "1.3.5",
-        "redis-parser": "2.6.0"
-      }
+      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A=="
     },
     "redis-commands": {
       "version": "1.3.5",
@@ -8915,21 +5986,12 @@
     "regenerator-transform": {
       "version": "0.9.11",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
-      "integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1",
-        "private": "0.1.7"
-      }
+      "integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM="
     },
     "regex-cache": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-      "requires": {
-        "is-equal-shallow": "0.1.3",
-        "is-primitive": "2.0.0"
-      }
+      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU="
     },
     "regexpp": {
       "version": "1.1.0",
@@ -8940,12 +6002,7 @@
     "regexpu-core": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "requires": {
-        "regenerate": "1.3.2",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
-      }
+      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA="
     },
     "regjsgen": {
       "version": "0.2.0",
@@ -8955,10 +6012,7 @@
     "regjsparser": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "requires": {
-        "jsesc": "0.5.0"
-      }
+      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw="
     },
     "relateurl": {
       "version": "0.2.7",
@@ -8983,10 +6037,7 @@
     "repeating": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "requires": {
-        "is-finite": "1.0.2"
-      }
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo="
     },
     "replace-ext": {
       "version": "0.0.1",
@@ -8997,30 +6048,6 @@
       "version": "2.81.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
       "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-      "requires": {
-        "aws-sign2": "0.6.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.1.4",
-        "har-validator": "4.2.1",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.15",
-        "oauth-sign": "0.8.2",
-        "performance-now": "0.2.0",
-        "qs": "6.4.0",
-        "safe-buffer": "5.0.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.2",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.0.1"
-      },
       "dependencies": {
         "uuid": {
           "version": "3.0.1",
@@ -9043,28 +6070,17 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
-      "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
-      }
+      "dev": true
     },
     "resolve": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
-      "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
-      "requires": {
-        "path-parse": "1.0.5"
-      }
+      "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU="
     },
     "resolve-dir": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
-      "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
-      "requires": {
-        "expand-tilde": "1.2.2",
-        "global-modules": "0.2.3"
-      }
+      "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4="
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -9076,37 +6092,24 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "dev": true,
-      "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
-      }
+      "dev": true
     },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "optional": true,
-      "requires": {
-        "align-text": "0.1.4"
-      }
+      "optional": true
     },
     "rimraf": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-      "requires": {
-        "glob": "7.1.2"
-      }
+      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0="
     },
     "run-async": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "dev": true,
-      "requires": {
-        "is-promise": "2.1.0"
-      }
+      "dev": true
     },
     "rx-lite": {
       "version": "4.0.8",
@@ -9118,10 +6121,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-      "dev": true,
-      "requires": {
-        "rx-lite": "4.0.8"
-      }
+      "dev": true
     },
     "safe-buffer": {
       "version": "5.0.1",
@@ -9138,12 +6138,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
-      "requires": {
-        "glob": "7.1.2",
-        "lodash": "4.17.4",
-        "scss-tokenizer": "0.2.3",
-        "yargs": "7.1.0"
-      },
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
@@ -9153,32 +6147,12 @@
         "cliui": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
-          }
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0="
         },
         "yargs": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
-          "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "5.0.0"
-          }
+          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg="
         }
       }
     },
@@ -9191,31 +6165,18 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
-      "requires": {
-        "js-base64": "2.1.9",
-        "source-map": "0.4.4"
-      },
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s="
         }
       }
     },
     "selenium-webdriver": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-3.4.0.tgz",
-      "integrity": "sha1-FR90RSlNpqZsScwwB0eioX5TxSo=",
-      "requires": {
-        "adm-zip": "0.4.7",
-        "rimraf": "2.6.1",
-        "tmp": "0.0.30",
-        "xml2js": "0.4.17"
-      }
+      "integrity": "sha1-FR90RSlNpqZsScwwB0eioX5TxSo="
     },
     "semver": {
       "version": "5.0.3",
@@ -9226,45 +6187,18 @@
       "version": "0.15.3",
       "resolved": "https://registry.npmjs.org/send/-/send-0.15.3.tgz",
       "integrity": "sha1-UBP5+ZAj31DRvZiSwZ4979HVMwk=",
-      "requires": {
-        "debug": "2.6.7",
-        "depd": "1.1.0",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.0",
-        "fresh": "0.5.0",
-        "http-errors": "1.6.1",
-        "mime": "1.3.4",
-        "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.3.1"
-      },
       "dependencies": {
         "debug": {
           "version": "2.6.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "requires": {
-            "ms": "2.0.0"
-          }
+          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4="
         }
       }
     },
     "sendgrid": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/sendgrid/-/sendgrid-5.1.1.tgz",
-      "integrity": "sha1-1LK2khrOteDI4exeAyYX//tZhyE=",
-      "requires": {
-        "async.ensureasync": "0.5.2",
-        "async.queue": "0.5.2",
-        "bottleneck": "1.15.1",
-        "debug": "2.6.8",
-        "lodash.chunk": "4.2.0",
-        "mailparser": "0.6.2",
-        "sendgrid-rest": "2.3.0"
-      }
+      "integrity": "sha1-1LK2khrOteDI4exeAyYX//tZhyE="
     },
     "sendgrid-rest": {
       "version": "2.3.0",
@@ -9279,13 +6213,7 @@
     "serve-static": {
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz",
-      "integrity": "sha1-n0uhni8wMMVH+K+ZEHg47DjVseI=",
-      "requires": {
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.1",
-        "send": "0.15.3"
-      }
+      "integrity": "sha1-n0uhni8wMMVH+K+ZEHg47DjVseI="
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -9301,32 +6229,11 @@
       "version": "0.17.3",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.17.3.tgz",
       "integrity": "sha1-SEzSpwyQA3CUjcxD4WX3gwa/9Io=",
-      "requires": {
-        "caw": "2.0.0",
-        "color": "1.0.3",
-        "got": "6.7.1",
-        "nan": "2.6.2",
-        "semver": "5.5.0",
-        "tar": "2.2.1"
-      },
       "dependencies": {
         "got": {
           "version": "6.7.1",
           "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-          "requires": {
-            "create-error-class": "3.0.2",
-            "duplexer3": "0.1.4",
-            "get-stream": "3.0.0",
-            "is-redirect": "1.0.0",
-            "is-retry-allowed": "1.1.0",
-            "is-stream": "1.1.0",
-            "lowercase-keys": "1.0.0",
-            "safe-buffer": "5.0.1",
-            "timed-out": "4.0.1",
-            "unzip-response": "2.0.1",
-            "url-parse-lax": "1.0.0"
-          }
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA="
         },
         "semver": {
           "version": "5.5.0",
@@ -9339,10 +6246,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
-      "requires": {
-        "shebang-regex": "1.0.0"
-      }
+      "dev": true
     },
     "shebang-regex": {
       "version": "1.0.0",
@@ -9364,9 +6268,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-      "requires": {
-        "is-arrayish": "0.3.1"
-      },
       "dependencies": {
         "is-arrayish": {
           "version": "0.3.1",
@@ -9385,9 +6286,6 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
-      "requires": {
-        "is-fullwidth-code-point": "2.0.0"
-      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -9400,32 +6298,17 @@
     "smtp-connection": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-2.12.0.tgz",
-      "integrity": "sha1-1275EnyyPCJZ7bHoNJwujV4tdME=",
-      "requires": {
-        "httpntlm": "1.6.1",
-        "nodemailer-shared": "1.1.0"
-      }
+      "integrity": "sha1-1275EnyyPCJZ7bHoNJwujV4tdME="
     },
     "sntp": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "requires": {
-        "hoek": "2.16.3"
-      }
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
     },
     "socket.io": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.0.2.tgz",
       "integrity": "sha1-EzvzobZ9AvKsZRA8EfeObyxPOzo=",
-      "requires": {
-        "debug": "2.6.8",
-        "engine.io": "3.1.0",
-        "object-assign": "4.1.1",
-        "socket.io-adapter": "1.1.0",
-        "socket.io-client": "2.0.2",
-        "socket.io-parser": "3.1.2"
-      },
       "dependencies": {
         "object-assign": {
           "version": "4.1.1",
@@ -9438,17 +6321,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.0.tgz",
       "integrity": "sha1-x6pGUB3VVsLLiiivj/lcC14dqkw=",
-      "requires": {
-        "debug": "2.3.3"
-      },
       "dependencies": {
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "requires": {
-            "ms": "0.7.2"
-          }
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w="
         },
         "ms": {
           "version": "0.7.2",
@@ -9460,33 +6337,12 @@
     "socket.io-client": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.0.2.tgz",
-      "integrity": "sha1-hvWdtZuhFockIg85viga1Jr3QsE=",
-      "requires": {
-        "backo2": "1.0.2",
-        "base64-arraybuffer": "0.1.5",
-        "component-bind": "1.0.0",
-        "component-emitter": "1.2.1",
-        "debug": "2.6.8",
-        "engine.io-client": "3.1.1",
-        "has-cors": "1.1.0",
-        "indexof": "0.0.1",
-        "object-component": "0.0.3",
-        "parseqs": "0.0.5",
-        "parseuri": "0.0.5",
-        "socket.io-parser": "3.1.2",
-        "to-array": "0.1.4"
-      }
+      "integrity": "sha1-hvWdtZuhFockIg85viga1Jr3QsE="
     },
     "socket.io-parser": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.1.2.tgz",
       "integrity": "sha1-28IoIVH8T6675Aru3Ady66YZ9/I=",
-      "requires": {
-        "component-emitter": "1.2.1",
-        "debug": "2.6.8",
-        "has-binary2": "1.0.2",
-        "isarray": "2.0.1"
-      },
       "dependencies": {
         "isarray": {
           "version": "2.0.1",
@@ -9499,18 +6355,11 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/socket.io-stream/-/socket.io-stream-0.9.1.tgz",
       "integrity": "sha1-QhJYMWKIuDrGk7DUPv0J1tQ6upc=",
-      "requires": {
-        "component-bind": "1.0.0",
-        "debug": "2.2.0"
-      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "requires": {
-            "ms": "0.7.1"
-          }
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo="
         },
         "ms": {
           "version": "0.7.1",
@@ -9532,10 +6381,7 @@
     "source-map-support": {
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
-      "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
-      "requires": {
-        "source-map": "0.5.6"
-      }
+      "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E="
     },
     "sparkles": {
       "version": "1.0.0",
@@ -9545,10 +6391,7 @@
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "requires": {
-        "spdx-license-ids": "1.2.2"
-      }
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A="
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
@@ -9575,17 +6418,6 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
       "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
-      "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jodid25519": "1.0.2",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
-      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -9607,10 +6439,7 @@
     "stdout-stream": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
-      "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
-      "requires": {
-        "readable-stream": "2.2.9"
-      }
+      "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s="
     },
     "stream-buffers": {
       "version": "3.0.1",
@@ -9620,34 +6449,22 @@
     "stream-combiner": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-      "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
-      "requires": {
-        "duplexer": "0.1.1",
-        "through": "2.3.8"
-      }
+      "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg="
     },
     "stream-consume": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
       "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8="
     },
-    "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
-      }
-    },
     "string_decoder": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-      "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-      "requires": {
-        "safe-buffer": "5.0.1"
-      }
+      "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg="
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
     },
     "stringstream": {
       "version": "0.0.5",
@@ -9657,27 +6474,17 @@
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
     },
     "strip-bom": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-      "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
-      "requires": {
-        "first-chunk-stream": "1.0.0",
-        "is-utf8": "0.2.1"
-      }
+      "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q="
     },
     "strip-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "requires": {
-        "get-stdin": "4.0.1"
-      }
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI="
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -9694,26 +6501,12 @@
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
-      "requires": {
-        "ajv": "5.5.2",
-        "ajv-keywords": "2.1.1",
-        "chalk": "2.4.1",
-        "lodash": "4.17.4",
-        "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
-      },
       "dependencies": {
         "ajv": {
           "version": "5.5.2",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.1.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
-          }
+          "dev": true
         },
         "ansi-regex": {
           "version": "3.0.0",
@@ -9725,21 +6518,13 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.0"
-          }
+          "dev": true
         },
         "chalk": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
-          }
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -9751,52 +6536,31 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
+          "dev": true
         },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
+          "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-          "dev": true,
-          "requires": {
-            "has-flag": "3.0.0"
-          }
+          "dev": true
         }
       }
     },
     "tar": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-      "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
-      }
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE="
     },
     "tar-stream": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
-      "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
-      "requires": {
-        "bl": "1.2.1",
-        "end-of-stream": "1.4.0",
-        "readable-stream": "2.2.9",
-        "xtend": "4.0.1"
-      }
+      "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY="
     },
     "text-table": {
       "version": "0.2.0",
@@ -9812,19 +6576,12 @@
     "through2": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-      "requires": {
-        "readable-stream": "2.2.9",
-        "xtend": "4.0.1"
-      }
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4="
     },
     "tildify": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
-      "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
-      "requires": {
-        "os-homedir": "1.0.2"
-      }
+      "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo="
     },
     "time-stamp": {
       "version": "1.1.0",
@@ -9839,10 +6596,7 @@
     "tmp": {
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.30.tgz",
-      "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
-      "requires": {
-        "os-tmpdir": "1.0.2"
-      }
+      "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0="
     },
     "to-array": {
       "version": "0.1.4",
@@ -9858,17 +6612,11 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
       "integrity": "sha1-Ua7z1ElXHU8oel2Hyci0kYGg2x0=",
-      "requires": {
-        "nopt": "1.0.10"
-      },
       "dependencies": {
         "nopt": {
           "version": "1.0.10",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-          "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-          "requires": {
-            "abbrev": "1.1.0"
-          }
+          "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4="
         }
       }
     },
@@ -9876,9 +6624,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-      "requires": {
-        "punycode": "1.4.1"
-      },
       "dependencies": {
         "punycode": {
           "version": "1.4.1",
@@ -9910,10 +6655,7 @@
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "5.0.1"
-      }
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -9925,10 +6667,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "1.1.2"
-      }
+      "dev": true
     },
     "type-detect": {
       "version": "4.0.3",
@@ -9938,11 +6677,7 @@
     "type-is": {
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
-      "requires": {
-        "media-typer": "0.3.0",
-        "mime-types": "2.1.15"
-      }
+      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA="
     },
     "typedarray": {
       "version": "0.0.6",
@@ -9953,11 +6688,7 @@
     "uglify-js": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.11.tgz",
-      "integrity": "sha1-gfWUuaJNrXbjnakvjwbls7yMLhE=",
-      "requires": {
-        "commander": "2.9.0",
-        "source-map": "0.5.6"
-      }
+      "integrity": "sha1-gfWUuaJNrXbjnakvjwbls7yMLhE="
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
@@ -9968,10 +6699,7 @@
     "uid-safe": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.4.tgz",
-      "integrity": "sha1-Otbzg2jG1MjHXsF2I/t5qh0HHYE=",
-      "requires": {
-        "random-bytes": "1.0.0"
-      }
+      "integrity": "sha1-Otbzg2jG1MjHXsF2I/t5qh0HHYE="
     },
     "uid2": {
       "version": "0.0.3",
@@ -9997,6 +6725,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
       "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs="
+    },
+    "universal-user-agent": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.0.1.tgz",
+      "integrity": "sha512-vz+heWVydO0iyYAa65VHD7WZkYzhl7BeNVy4i54p4TF8OMiLSXdbuQe4hm+fmWAsL+rVibaQHXfhvkw3c1Ws2w=="
     },
     "universalify": {
       "version": "0.1.0",
@@ -10026,11 +6759,7 @@
     "url": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      }
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ="
     },
     "url-join": {
       "version": "2.0.2",
@@ -10040,10 +6769,12 @@
     "url-parse-lax": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-      "requires": {
-        "prepend-http": "1.0.4"
-      }
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM="
+    },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
     },
     "user-home": {
       "version": "1.1.1",
@@ -10054,9 +6785,6 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-      "requires": {
-        "inherits": "2.0.1"
-      },
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
@@ -10078,10 +6806,7 @@
     "uue": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uue/-/uue-3.1.0.tgz",
-      "integrity": "sha1-XWfTcDDmbv67tLiqxG2vm1W++/Y=",
-      "requires": {
-        "extend": "3.0.1"
-      }
+      "integrity": "sha1-XWfTcDDmbv67tLiqxG2vm1W++/Y="
     },
     "uws": {
       "version": "0.14.5",
@@ -10092,19 +6817,12 @@
     "v8flags": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
-      "requires": {
-        "user-home": "1.1.1"
-      }
+      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ="
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
-      }
+      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w="
     },
     "vary": {
       "version": "1.1.1",
@@ -10114,36 +6832,22 @@
     "verror": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-      "requires": {
-        "extsprintf": "1.0.2"
-      }
+      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
     },
     "vinyl": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-      "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-      "requires": {
-        "clone": "1.0.2",
-        "clone-stats": "0.0.1",
-        "replace-ext": "0.0.1"
-      }
+      "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4="
     },
     "vinyl-bufferstream": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/vinyl-bufferstream/-/vinyl-bufferstream-1.0.1.tgz",
       "integrity": "sha1-BTeGn1gO/6TKRay0dXnkuf5jCBo=",
-      "requires": {
-        "bufferstreams": "1.0.1"
-      },
       "dependencies": {
         "bufferstreams": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.0.1.tgz",
-          "integrity": "sha1-z7GtlWjTujz+k1upq92VLeiKqyo=",
-          "requires": {
-            "readable-stream": "1.1.14"
-          }
+          "integrity": "sha1-z7GtlWjTujz+k1upq92VLeiKqyo="
         },
         "isarray": {
           "version": "0.0.1",
@@ -10153,13 +6857,7 @@
         "readable-stream": {
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk="
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -10172,16 +6870,6 @@
       "version": "0.3.14",
       "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
       "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
-      "requires": {
-        "defaults": "1.0.3",
-        "glob-stream": "3.1.18",
-        "glob-watcher": "0.0.6",
-        "graceful-fs": "3.0.11",
-        "mkdirp": "0.5.1",
-        "strip-bom": "1.0.0",
-        "through2": "0.6.5",
-        "vinyl": "0.4.6"
-      },
       "dependencies": {
         "clone": {
           "version": "0.2.0",
@@ -10191,10 +6879,7 @@
         "graceful-fs": {
           "version": "3.0.11",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-          "requires": {
-            "natives": "1.1.0"
-          }
+          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg="
         },
         "isarray": {
           "version": "0.0.1",
@@ -10204,13 +6889,7 @@
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw="
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -10220,30 +6899,19 @@
         "through2": {
           "version": "0.6.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
-          }
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg="
         },
         "vinyl": {
           "version": "0.4.6",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-          "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-          "requires": {
-            "clone": "0.2.0",
-            "clone-stats": "0.0.1"
-          }
+          "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc="
         }
       }
     },
     "vinyl-sourcemaps-apply": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
-      "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
-      "requires": {
-        "source-map": "0.5.6"
-      }
+      "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU="
     },
     "walkdir": {
       "version": "0.0.11",
@@ -10258,10 +6926,7 @@
     "which": {
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-      "requires": {
-        "isexe": "2.0.0"
-      }
+      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU="
     },
     "which-module": {
       "version": "1.0.0",
@@ -10271,10 +6936,12 @@
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-      "requires": {
-        "string-width": "1.0.2"
-      }
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w=="
+    },
+    "win-release": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
+      "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk="
     },
     "window-size": {
       "version": "0.1.0",
@@ -10290,11 +6957,7 @@
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
-      }
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU="
     },
     "wrappy": {
       "version": "1.0.2",
@@ -10305,19 +6968,12 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "0.5.1"
-      }
+      "dev": true
     },
     "ws": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
-      "integrity": "sha1-a5Sz5EfLajY/eF6vlK9jWejoHIA=",
-      "requires": {
-        "safe-buffer": "5.0.1",
-        "ultron": "1.1.0"
-      }
+      "integrity": "sha1-a5Sz5EfLajY/eF6vlK9jWejoHIA="
     },
     "xml-char-classes": {
       "version": "1.0.0",
@@ -10327,19 +6983,12 @@
     "xml2js": {
       "version": "0.4.17",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
-      "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
-      "requires": {
-        "sax": "1.2.1",
-        "xmlbuilder": "4.2.1"
-      }
+      "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg="
     },
     "xmlbuilder": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
-      "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
-      "requires": {
-        "lodash": "4.17.4"
-      }
+      "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU="
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.3",
@@ -10366,12 +7015,6 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "optional": true,
-      "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
-        "window-size": "0.1.0"
-      },
       "dependencies": {
         "camelcase": {
           "version": "1.2.1",
@@ -10385,9 +7028,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
       "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
-      "requires": {
-        "camelcase": "3.0.0"
-      },
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
@@ -10404,13 +7044,7 @@
     "zip-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.1.1.tgz",
-      "integrity": "sha1-Uha0i7tNJlH2TVxubwnrSnOZ1Vc=",
-      "requires": {
-        "archiver-utils": "1.3.0",
-        "compress-commons": "1.2.0",
-        "lodash": "4.17.4",
-        "readable-stream": "2.2.9"
-      }
+      "integrity": "sha1-Uha0i7tNJlH2TVxubwnrSnOZ1Vc="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/fossasia/open-event-webapp#readme",
   "dependencies": {
+    "@octokit/rest": "^15.12.1",
     "archiver": "^1.0.0",
     "async": "^2.0.0-rc.6",
     "aws-sdk": "^2.62.0",
@@ -38,7 +39,6 @@
     "fs": "0.0.2",
     "fs-extra": "^3.0.1",
     "ftp-deploy": "^1.1.0",
-    "github": "^9.2.0",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-clean": "^0.3.2",

--- a/src/backend/deploy.js
+++ b/src/backend/deploy.js
@@ -3,7 +3,7 @@
 
 const distHelper = require('./dist.js');
 const fs = require('fs');
-const Github = require('github');
+const Github = require('@octokit/rest');
 const gh = new Github();
 const async = require('async');
 let results, bitmap, i, file, fullPath, eventName, repoName, total, counter, elem, fileName, sha;


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:


#### Changes proposed in this pull request:

-The deprecated dependency  `github` is renamed to `@octokit/rest`
-
-
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2113 
