### PR TITLE
Add "Organized by" section

### DIFF
--- a/src/backend/fold_v1.js
+++ b/src/backend/fold_v1.js
@@ -502,6 +502,7 @@ function extractEventUrls(event, speakers, sponsors, reqOpts, next) {
     tweetUrl: sociallink,
     email: event.email,
     orgname: event.organizer_name,
+    orgdescription: event.organizer_description,
     location_name: event.location_name,
     featuresection: featuresection,
     sponsorsection: sponsorsection,

--- a/src/backend/fold_v2.js
+++ b/src/backend/fold_v2.js
@@ -532,6 +532,7 @@ function extractEventUrls(event, speakers, sponsors, reqOpts, next) {
     tweetUrl: sociallink,
     email: event.email,
     orgname: event['organizer-name'],
+    orgdescription: event['organizer-description'],
     location_name: event['location-name'],
     featuresection: featuresection,
     sponsorsection: sponsorsection,

--- a/src/backend/templates/event.hbs
+++ b/src/backend/templates/event.hbs
@@ -164,6 +164,19 @@
       </div>
     {{/if}}
 
+    {{#if eventurls.orgdescription}}
+      <div class="col-sm-12 col-md-12 col-xs-12 text-center">
+        <h1 class="section-header">Organized by {{eventurls.orgname}}</h1><br>
+      </div>
+      <section class="container">
+        <div class="col-sm-12 col-md-12 col-xs-12">
+          <p>
+            {{eventurls.orgdescription}}
+          </p>
+        </div>
+      </section>
+    {{/if}}
+
     {{#if eventurls.sponsorsection}}
       <div class="sponsor-container">
         <section class="sponsorscont">


### PR DESCRIPTION
#### Short description of what this resolves:
Add "Organized by" section below the tweet section.

![organizedby](https://user-images.githubusercontent.com/27485533/46570068-5a206400-c97c-11e8-82ff-90119de4de12.png)

Fixes #2090.
