### PR TITLE
fix: Run a batch of 15 tasks in parallel

### DIFF
--- a/src/backend/dist.js
+++ b/src/backend/dist.js
@@ -263,7 +263,7 @@ const resizeSpeakers = function(dir, socket, done) {
     if (err) {
       logger.addLog('Info', 'No sponsors images found', socket, err);
     }
-    async.each(list, function(image, trial) {
+    async.eachLimit(list, 15, function(image, trial) {
       sharp(dir + '/speakers/' + image)
         .resize({
           width: 264,


### PR DESCRIPTION


<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
- Earlier since there was no limit on the batch size so due to limited resources any subsequent request got queued in the last of these tasks
- Now since we are processing in a batch of 15, any new request will only get queued at the end of these 15 tasks

#### Changes proposed in this pull request:

- Used async.eachLimit with 15 as the limit of parallel task at a time instead of async.each which had no limit.
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

